### PR TITLE
better Docker configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 yarn.lock
 dist
 mango
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,11 @@ RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources
 
 RUN apt-get update && apt-get install -y nodejs yarn libsqlite3-dev
 
-RUN git clone https://github.com/hkalexling/Mango
-RUN cd Mango && make && make install
+WORKDIR /Mango
+
+COPY . .
+COPY package*.json .
+
+RUN make && make install
+
+CMD ["mango"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Mango is a self-hosted manga server and reader. Its features include
 2. Clone the repository
 3. `docker build -t mango:mango .`
 4. `docker run -td --name mango -p 9000:9000 -v /path/to/your/mango/library:/root/mango/library mango:mango`
-5. Now the docker container is up and running. You can get into it using `docker exec -it mango /bin/bash` and then start Mango using the command `mango`
+5. or you can directly run it with `docker-compose up` (You should create your own docker-compose.yml configuration file before running it)
+6. Now the docker container is up and running. You can visit at `http://127.0.0.1:9000`.
 
 ### Build from source
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,18 @@
+version: '3'
+
+services:
+  mango:
+    container_name: mango
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    expose:
+      - 9000
+    ports:
+      - 9000:9000
+    volumes:
+      - library:/root/mango/library
+      - config:/root/.config/mango
+volumes:
+  library:
+  config:


### PR DESCRIPTION
maybe better preference to use Docker:

### Dockerfile
* `COPY` project files directly from local instead of git-cloned
* add `CMD` into `Dockerfile`, so we don't need run command `mango` in the cotainer after running mango instance

### Docker Compose
* add `docker-compose.example.yml` as example configuration
* add `docker-compose.yml` into `.gitignore`
