### PR TITLE
Use a .env file for docker-compose configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ node_modules
 yarn.lock
 dist
 mango
-docker-compose.yml
+.env

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Simply download the pre-built binary file `mango` for the latest [release](https
 
 1. Make sure you have docker installed and running. You will also need `docker-compose`
 2. Clone the repository
-3. Copy `docker-compose.example.yml` to `docker-compose.yml`
-4. Modify the `volumes` in `docker-compose.yml` to point the directories to desired locations on the host machine
+3. Copy the `env.example` file to `.env`
+4. Fill out the values in the `.env` file. Note that the main and config directories will be created if they don't already exist. The files in these folders will be owned by the root user
 5. Run `docker-compose up`. This should build the docker image and start the container with Mango running inside
-6. Head over to `localhost:9000` to log in
+6. Head over to `localhost:9000` (or a different port if you changed it) to log in
 
 ### Docker (via Dockerhub)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ services:
       context: .
       dockerfile: ./Dockerfile
     expose:
-      - 9000
+      - ${PORT}
     ports:
-      - 9000:9000
+      - "${PORT}:9000"
     volumes:
-      - ~/mango:/root/mango
-      - ~/.config/mango:/root/.config/mango
+      - ${MAIN_DIRECTORY_PATH}:/root/mango
+      - ${CONFIG_DIRECTORY_PATH}:/root/.config/mango

--- a/env.example
+++ b/env.example
@@ -1,0 +1,10 @@
+# Port that exposes the HTTP frontend
+PORT=9000
+
+# Path to the mango main directory
+# This directory holds the database and the library files
+MAIN_DIRECTORY_PATH=
+
+# Path to the mango config directory
+# This directory holds the mango configuration path
+CONFIG_DIRECTORY_PATH=


### PR DESCRIPTION
This is generally cleaner and ensures that the `docker-compose.yml` can be a part of the source repository (which allows for updating it).

For future reference, it's possible to use any variable in the `.env` file (which follows the syntax of `VARNAME=value`) in `docker-compose.yml` by using `${VARNAME}`.

--

This does break existing configurations and pulls, if you merge this users _will_ have to create a `.env` file. I also added some comments as to what each variable does/stands for.