### PR TITLE
Make file extension check case-insensitive

### DIFF
--- a/spec/util_spec.cr
+++ b/spec/util_spec.cr
@@ -35,6 +35,26 @@ describe "compare_numerically" do
   end
 end
 
+describe "is_interesting_file" do
+  it "returns true when filename has interesting file extension" do
+    filename = "manga.cbz"
+    result = is_interesting_file filename
+    result.should eq true
+  end
+
+  it "returns false if file extension is not interesting" do
+    filename = "info.json"
+    result = is_interesting_file filename
+    result.should eq false
+  end
+
+  it "returns true when fileext has uppercase" do
+    filename = "manga.ZiP"
+    result = is_interesting_file filename
+    result.should eq true
+  end
+end
+
 describe "chapter_sort" do
   it "sorts correctly" do
     ary = ["Vol.1 Ch.01", "Vol.1 Ch.02", "Vol.2 Ch. 2.5", "Ch. 3", "Ch.04"]

--- a/spec/util_spec.cr
+++ b/spec/util_spec.cr
@@ -35,23 +35,20 @@ describe "compare_numerically" do
   end
 end
 
-describe "is_interesting_file" do
-  it "returns true when filename has interesting file extension" do
+describe "is_supported_file" do
+  it "returns true when the filename has a supported extension" do
     filename = "manga.cbz"
-    result = is_interesting_file filename
-    result.should eq true
+    is_supported_file(filename).should eq true
   end
 
-  it "returns false if file extension is not interesting" do
+  it "returns true when the filename does not have a supported extension" do
     filename = "info.json"
-    result = is_interesting_file filename
-    result.should eq false
+    is_supported_file(filename).should eq false
   end
 
-  it "returns true when fileext has uppercase" do
+  it "is case insensitive" do
     filename = "manga.ZiP"
-    result = is_interesting_file filename
-    result.should eq true
+    is_supported_file(filename).should eq true
   end
 end
 

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -36,7 +36,7 @@ class Title
         @title_ids << title.id
         next
       end
-      if [".zip", ".cbz", ".rar", ".cbr"].includes? (File.extname path).downcase
+      if is_interesting_file path
         entry = Entry.new path, self
         @entries << entry if entry.pages > 0 || entry.err_msg
       end

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -36,7 +36,7 @@ class Title
         @title_ids << title.id
         next
       end
-      if is_interesting_file path
+      if is_supported_file path
         entry = Entry.new path, self
         @entries << entry if entry.pages > 0 || entry.err_msg
       end

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -36,7 +36,7 @@ class Title
         @title_ids << title.id
         next
       end
-      if [".zip", ".cbz", ".rar", ".cbr"].includes? File.extname path
+      if [".zip", ".cbz", ".rar", ".cbr"].includes? (File.extname path).downcase
         entry = Entry.new path, self
         @entries << entry if entry.pages > 0 || entry.err_msg
       end

--- a/src/util/signature.cr
+++ b/src/util/signature.cr
@@ -13,7 +13,7 @@ class File
   #   ensures that moving (unless to another device) and renaming the file
   #   preserves the signature, while copying or editing the file changes it.
   def self.signature(filename) : UInt64
-    return 0u64 unless is_interesting_file filename
+    return 0u64 unless is_supported_file filename
     info = File.info filename
     signatures = [
       info.inode,

--- a/src/util/signature.cr
+++ b/src/util/signature.cr
@@ -1,3 +1,5 @@
+require "./util"
+
 class File
   abstract struct Info
     def inode
@@ -11,7 +13,7 @@ class File
   #   ensures that moving (unless to another device) and renaming the file
   #   preserves the signature, while copying or editing the file changes it.
   def self.signature(filename) : UInt64
-    return 0u64 unless %w(.zip .rar .cbz .cbr).includes? File.extname filename
+    return 0u64 unless is_interesting_file filename
     info = File.info filename
     signatures = [
       info.inode,

--- a/src/util/util.cr
+++ b/src/util/util.cr
@@ -1,7 +1,8 @@
-IMGS_PER_PAGE            = 5
-ENTRIES_IN_HOME_SECTIONS = 8
-UPLOAD_URL_PREFIX        = "/uploads"
-STATIC_DIRS              = ["/css", "/js", "/img", "/favicon.ico"]
+IMGS_PER_PAGE             = 5
+ENTRIES_IN_HOME_SECTIONS  = 8
+UPLOAD_URL_PREFIX         = "/uploads"
+STATIC_DIRS               = ["/css", "/js", "/img", "/favicon.ico"]
+INTERESTING_FILE_EXTNAMES = [".zip", ".cbz", ".rar", ".cbr"]
 
 def random_str
   UUID.random.to_s.gsub "-", ""
@@ -29,6 +30,10 @@ def register_mime_types
   }.each do |k, v|
     MIME.register k, v
   end
+end
+
+def is_interesting_file(path)
+  INTERESTING_FILE_EXTNAMES.includes? (File.extname path).downcase
 end
 
 struct Int

--- a/src/util/util.cr
+++ b/src/util/util.cr
@@ -1,8 +1,8 @@
-IMGS_PER_PAGE             = 5
-ENTRIES_IN_HOME_SECTIONS  = 8
-UPLOAD_URL_PREFIX         = "/uploads"
-STATIC_DIRS               = ["/css", "/js", "/img", "/favicon.ico"]
-INTERESTING_FILE_EXTNAMES = [".zip", ".cbz", ".rar", ".cbr"]
+IMGS_PER_PAGE            = 5
+ENTRIES_IN_HOME_SECTIONS = 8
+UPLOAD_URL_PREFIX        = "/uploads"
+STATIC_DIRS              = ["/css", "/js", "/img", "/favicon.ico"]
+SUPPORTED_FILE_EXTNAMES  = [".zip", ".cbz", ".rar", ".cbr"]
 
 def random_str
   UUID.random.to_s.gsub "-", ""
@@ -32,8 +32,8 @@ def register_mime_types
   end
 end
 
-def is_interesting_file(path)
-  INTERESTING_FILE_EXTNAMES.includes? (File.extname path).downcase
+def is_supported_file(path)
+  SUPPORTED_FILE_EXTNAMES.includes? File.extname(path).downcase
 end
 
 struct Int


### PR DESCRIPTION
I realized that I had several files which of filename is ended with '.CBZ', and they are not scanned by Mango.
(they are generated by accident, when moving Linux files whose name contains forbidden characters in Windows via Samba haha...)

I resolved this problem by adding `is_interesting_file` method.