### PR TITLE
Fix incorrect background color on reader page

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ master, dev ]
+    branches: [ master, dev, hotfix/* ]
   pull_request:
     branches: [ master, dev ]
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The official docker images are available on [Dockerhub](https://hub.docker.com/r
 ### CLI
 
 ```
-  Mango - Manga Server and Web Reader. Version 0.19.0
+  Mango - Manga Server and Web Reader. Version 0.19.1
 
   Usage:
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: mango
-version: 0.19.0
+version: 0.19.1
 
 authors:
   - Alex Ling <hkalexling@gmail.com>

--- a/src/mango.cr
+++ b/src/mango.cr
@@ -8,7 +8,7 @@ require "option_parser"
 require "clim"
 require "tallboy"
 
-MANGO_VERSION = "0.19.0"
+MANGO_VERSION = "0.19.1"
 
 # From http://www.network-science.de/ascii/
 BANNER = %{

--- a/src/views/reader.html.ecr
+++ b/src/views/reader.html.ecr
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html style="background-color: black;">
+<html class="reader-bg">
 
   <% page = "Reader" %>
   <%= render_component "head" %>
@@ -112,6 +112,7 @@
   <style>
 img[data-src][src*='data:image'] { background: white; }
 img { width: 100%; }
+.reader-bg { background: black; }
   </style>
 
 </html>


### PR DESCRIPTION
In [v0.19.0](https://github.com/hkalexling/Mango/releases/tag/v0.19.0) we switched from raw CSS to Less, but that accidentically introduced a bug where the background color on the reader page becomes white instead of black. It's now fixed in this PR.