### PR TITLE
Fix HTTP 500 Error when accessing the favicon

### DIFF
--- a/src/util/util.cr
+++ b/src/util/util.cr
@@ -27,6 +27,7 @@ def register_mime_types
     ".rar" => "application/x-rar-compressed",
     ".cbz" => "application/vnd.comicbook+zip",
     ".cbr" => "application/vnd.comicbook-rar",
+    ".ico" => "image/x-icon",
   }.each do |k, v|
     MIME.register k, v
   end


### PR DESCRIPTION
Fix #158 

The server returns HTTP 500 error when requested '/favion.ico'
The handler worked fine, but send_file has failed with the error `Missing MIME type for extension ".ico"`
so I register mime type for .ico file