### PR TITLE
HTTP cache for thumbnails, pages, dimensions

### DIFF
--- a/src/routes/api.cr
+++ b/src/routes/api.cr
@@ -76,6 +76,7 @@ struct APIRouter
     Koa.path "page", schema: Int32, desc: "The page number to return (starts from 1)"
     Koa.response 200, schema: Bytes, media_type: "image/*"
     Koa.response 500, "Page not found or not readable"
+    Koa.response 304, "Page not modified (only available when `If-None-Match` is set)"
     Koa.tag "reader"
     get "/api/page/:tid/:eid/:page" do |env|
       begin
@@ -111,7 +112,7 @@ struct APIRouter
     Koa.path "tid", desc: "Title ID"
     Koa.path "eid", desc: "Entry ID"
     Koa.response 200, schema: Bytes, media_type: "image/*"
-    Koa.response 304, ""
+    Koa.response 304, "Page not modified (only available when `If-None-Match` is set)"
     Koa.response 500, "Page not found or not readable"
     Koa.tag "library"
     get "/api/cover/:tid/:eid" do |env|
@@ -649,7 +650,7 @@ struct APIRouter
         "height" => Int32,
       }],
     }
-    Koa.response 304
+    Koa.response 304, "Not modified (only available when `If-None-Match` is set)"
     get "/api/dimensions/:tid/:eid" do |env|
       begin
         tid = env.params.url["tid"]

--- a/src/routes/api.cr
+++ b/src/routes/api.cr
@@ -99,6 +99,7 @@ struct APIRouter
           ""
         else
           env.response.headers["ETag"] = e_tag
+          env.response.headers["Cache-Control"] = "public, max-age=86400"
           send_img env, img
         end
       rescue e
@@ -670,6 +671,7 @@ struct APIRouter
         else
           sizes = entry.page_dimensions
           env.response.headers["ETag"] = e_tag
+          env.response.headers["Cache-Control"] = "public, max-age=86400"
           send_json env, {
             "success"    => true,
             "dimensions" => sizes,


### PR DESCRIPTION
Use [`ETag`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) header for HTTP caching

* thumbnails and pages
  * hashing image data with SHA1 (strong validation)
  * Resolve #213 
* dimensions
  * It took so long times for big manga files, since it requires to read an entire zip file. For the device that has a bad I/O performance, It would be helped.
  * I use a zip_path of an entry and its mtime for hashing (SHA1), set ETag for weak validation