### PR TITLE
Enhance the paged mode reader

### DIFF
--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -11,6 +11,7 @@ const readerComponent = () => {
 		lastSavedPage: page,
 		selectedIndex: 0, // 0: not selected; 1: the first page
 		margin: 30,
+		preloadLookahead: 3,
 
 		/**
 		 * Initialize the component by fetching the page dimensions
@@ -52,6 +53,13 @@ const readerComponent = () => {
 					if (savedMargin) {
 						this.margin = savedMargin;
 					}
+
+					// Preload Images
+					this.preloadLookahead = 3;
+					const limit = Math.min(page + this.preloadLookahead, this.items.length + 1);
+					for (let idx = page + 1; idx <= limit; idx++) {
+						this.preloadImage(this.items[idx - 1].url);
+					}
 				})
 				.catch(e => {
 					const errMsg = `Failed to get the page dimensions. ${e}`;
@@ -59,6 +67,12 @@ const readerComponent = () => {
 					this.alertClass = 'uk-alert-danger';
 					this.msg = errMsg;
 				})
+		},
+		/**
+		 * Preload an image, which is expected to be cached
+		 */
+		preloadImage(url) {
+			(new Image()).src = url;
 		},
 		/**
 		 * Handles the `change` event for the page selector
@@ -110,6 +124,10 @@ const readerComponent = () => {
 			const newIdx = idx + (isNext ? 1 : -1);
 
 			if (newIdx <= 0 || newIdx > this.items.length) return;
+
+			if (newIdx + this.preloadLookahead < this.items.length + 1) {
+				this.preloadImage(this.items[newIdx + this.preloadLookahead - 1].url);
+			}
 
 			this.toPage(newIdx);
 

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -55,7 +55,7 @@ const readerComponent = () => {
 					}
 
 					// Preload Images
-					this.preloadLookahead = 3;
+					this.preloadLookahead = +localStorage.getItem('preloadLookahead') ?? 3;
 					const limit = Math.min(page + this.preloadLookahead, this.items.length + 1);
 					for (let idx = page + 1; idx <= limit; idx++) {
 						this.preloadImage(this.items[idx - 1].url);
@@ -305,6 +305,10 @@ const readerComponent = () => {
 		marginChanged() {
 			localStorage.setItem('margin', this.margin);
 			this.toPage(this.selectedIndex);
+		},
+
+		preloadLookaheadChanged() {
+			localStorage.setItem('preloadLookahead', this.preloadLookahead);
 		}
 	};
 }

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -56,7 +56,7 @@ const readerComponent = () => {
 					}
 
 					// Preload Images
-					this.preloadLookahead = +localStorage.getItem('preloadLookahead') ?? 3;
+					this.preloadLookahead = +(localStorage.getItem('preloadLookahead') ?? 3);
 					const limit = Math.min(page + this.preloadLookahead, this.items.length + 1);
 					for (let idx = page + 1; idx <= limit; idx++) {
 						this.preloadImage(this.items[idx - 1].url);

--- a/public/js/reader.js
+++ b/public/js/reader.js
@@ -6,6 +6,7 @@ const readerComponent = () => {
 		alertClass: 'uk-alert-primary',
 		items: [],
 		curItem: {},
+		enableFlipAnimation: true,
 		flipAnimation: null,
 		longPages: false,
 		lastSavedPage: page,
@@ -60,6 +61,9 @@ const readerComponent = () => {
 					for (let idx = page + 1; idx <= limit; idx++) {
 						this.preloadImage(this.items[idx - 1].url);
 					}
+
+					const savedFlipAnimation = localStorage.getItem('enableFlipAnimation');
+					this.enableFlipAnimation = savedFlipAnimation === null || savedFlipAnimation === 'true';
 				})
 				.catch(e => {
 					const errMsg = `Failed to get the page dimensions. ${e}`;
@@ -131,10 +135,12 @@ const readerComponent = () => {
 
 			this.toPage(newIdx);
 
-			if (isNext)
-				this.flipAnimation = 'right';
-			else
-				this.flipAnimation = 'left';
+			if (this.enableFlipAnimation) {
+				if (isNext)
+					this.flipAnimation = 'right';
+				else
+					this.flipAnimation = 'left';
+			}
 
 			setTimeout(() => {
 				this.flipAnimation = null;
@@ -309,6 +315,10 @@ const readerComponent = () => {
 
 		preloadLookaheadChanged() {
 			localStorage.setItem('preloadLookahead', this.preloadLookahead);
-		}
+		},
+
+		enableFlipAnimationChanged() {
+			localStorage.setItem('enableFlipAnimation', this.enableFlipAnimation);
+		},
 	};
 }

--- a/src/views/reader.html.ecr
+++ b/src/views/reader.html.ecr
@@ -21,7 +21,7 @@
       <div
         :class="{'uk-container': true, 'uk-container-small': mode === 'continuous', 'uk-container-expand': mode !== 'continuous'}">
         <div x-show="!loading && mode === 'continuous'" x-cloak>
-          <template x-for="item in items">
+          <template x-if="!loading && mode === 'continuous'" x-for="item in items">
             <img
               uk-img
               :class="{'uk-align-center': true, 'spine': item.width < 50}"

--- a/src/views/reader.html.ecr
+++ b/src/views/reader.html.ecr
@@ -98,6 +98,13 @@
             </div>
           </div>
 
+          <div class="uk-margin" x-show="mode !== 'continuous'">
+            <label class="uk-form-label" for="preload-lookahead" x-text="`Preload Image: ${preloadLookahead} page(s)`"></label>
+            <div class="uk-form-controls">
+              <input id="preload-lookahead" class="uk-range" type="range" min="0" max="5" step="1" x-model.number="preloadLookahead" @change="preloadLookaheadChanged()">
+            </div>
+          </div>
+
           <hr class="uk-divider-icon">
 
           <div class="uk-margin">

--- a/src/views/reader.html.ecr
+++ b/src/views/reader.html.ecr
@@ -101,7 +101,13 @@
             </div>
           </div>
 
-          <div class="uk-margin" x-show="mode !== 'continuous'">
+          <div class="uk-margin uk-form-horizontal" x-show="mode !== 'continuous'">
+            <label class="uk-form-label" for="enable-flip-animation">Enable Flip Animation</label>
+            <div class="uk-form-controls">
+              <input id="enable-flip-animation" class="uk-checkbox" type="checkbox" x-model="enableFlipAnimation" @change="enableFlipAnimationChanged()">
+            </div>
+          </div>
+          <div class="uk-margin uk-form-horizontal" x-show="mode !== 'continuous'">
             <label class="uk-form-label" for="preload-lookahead" x-text="`Preload Image: ${preloadLookahead} page(s)`"></label>
             <div class="uk-form-controls">
               <input id="preload-lookahead" class="uk-range" type="range" min="0" max="5" step="1" x-model.number="preloadLookahead" @change="preloadLookaheadChanged()">

--- a/src/views/reader.html.ecr
+++ b/src/views/reader.html.ecr
@@ -50,6 +50,9 @@
                                                                                                                                                                  width:${mode === 'width' ? '100vw' : 'auto'}; 
                                                                                                                                                                  height:${mode === 'height' ? '100vh' : 'auto'}; 
                                                                                                                                                                  margin-bottom:0;
+                                                                                                                                                                 max-width:100%;
+                                                                                                                                                                 max-height:100%;
+                                                                                                                                                                 object-fit: contain;
                                                                                                                                                                  `" />
 
           <div style="position:absolute;z-index:1; top:0;left:0; width:30%;height:100%;" @click="flipPage(false)"></div>


### PR DESCRIPTION
### 1. Preload next images

This resolve #196

![image](https://user-images.githubusercontent.com/6760150/129922730-44aade3b-28cb-4635-8c07-0d353f8aba49.png)
Preload lookahead: 3 pages
Started from p32, it preloaded next 3 pages (pp.33-35)
After reading p33 and p34, it preloaded p36, p37 each.

### 2. Prevent to load unnecessary images

Fix #217

### 3. Fix CSS to fit image 'contain' properly

Fix #218

### 4. Option for enabling/disabling a flip animation

This resolve one of suggestion from #147 

---

A below picture shows a modal menu when the mode is paged mode.
It has the checkbox for toggling flip animation and the range input to set preload pages

![image](https://user-images.githubusercontent.com/6760150/129922129-cceabc3d-6b1e-46fe-9616-c1a46cfa5283.png)

I'm curious that its layout looks good (especially about a position of the checkbox... 😜)