### PR TITLE
Improve loading pages (library, titles)

### DIFF
--- a/src/config.cr
+++ b/src/config.cr
@@ -20,6 +20,8 @@ class Config
   property plugin_path : String = File.expand_path "~/mango/plugins",
     home: true
   property download_timeout_seconds : Int32 = 30
+  property sorted_entries_cache_enable = false
+  property sorted_entries_cache_capacity_kbs = 51200
   property disable_login = false
   property default_username = ""
   property auth_proxy_header_name = ""

--- a/src/config.cr
+++ b/src/config.cr
@@ -20,8 +20,9 @@ class Config
   property plugin_path : String = File.expand_path "~/mango/plugins",
     home: true
   property download_timeout_seconds : Int32 = 30
-  property sorted_entries_cache_enable = false
-  property sorted_entries_cache_size_mbs = 50
+  property cache_enabled = false
+  property cache_size_mbs = 50
+  property cache_log_enabled = true
   property disable_login = false
   property default_username = ""
   property auth_proxy_header_name = ""

--- a/src/config.cr
+++ b/src/config.cr
@@ -21,7 +21,7 @@ class Config
     home: true
   property download_timeout_seconds : Int32 = 30
   property sorted_entries_cache_enable = false
-  property sorted_entries_cache_capacity_kbs = 51200
+  property sorted_entries_cache_size_mbs = 50
   property disable_login = false
   property default_username = ""
   property auth_proxy_header_name = ""

--- a/src/library/cache.cr
+++ b/src/library/cache.cr
@@ -1,0 +1,159 @@
+require "digest"
+
+class InfoCache
+  alias ProgressCache = Tuple(String, Int32)
+
+  def self.clear
+    clear_cover_url
+    clear_progress_cache
+    clear_sort_opt
+  end
+
+  def self.clean
+    clean_cover_url
+    clean_progress_cache
+    clean_sort_opt
+  end
+
+  # item id => cover_url
+  @@cached_cover_url = {} of String => String
+  @@cached_cover_url_previous = {} of String => String # item id => cover_url
+
+  def self.set_cover_url(id : String, cover_url : String)
+    @@cached_cover_url[id] = cover_url
+  end
+
+  def self.get_cover_url(id : String)
+    @@cached_cover_url[id]?
+  end
+
+  def self.invalidate_cover_url(id : String)
+    @@cached_cover_url.delete id
+  end
+
+  def self.move_cover_url(id : String)
+    if @@cached_cover_url_previous[id]?
+      @@cached_cover_url[id] = @@cached_cover_url_previous[id]
+    end
+  end
+
+  private def self.clear_cover_url
+    @@cached_cover_url_previous = @@cached_cover_url
+    @@cached_cover_url = {} of String => String
+  end
+
+  private def self.clean_cover_url
+    @@cached_cover_url_previous = {} of String => String
+  end
+
+  # book.id:username => {signature, sum}
+  @@progress_cache = {} of String => ProgressCache
+  # book.id => username => {signature, sum}
+  @@progress_cache_previous = {} of String => Hash(String, ProgressCache)
+
+  def self.set_progress_cache(book_id : String, username : String,
+                              entries : Array(Entry), sum : Int32)
+    progress_cache_id = "#{book_id}:#{username}"
+    progress_cache_sig = Digest::SHA1.hexdigest (entries.map &.id).to_s
+    @@progress_cache[progress_cache_id] = {progress_cache_sig, sum}
+    Logger.debug "Progress Cached #{progress_cache_id}"
+  end
+
+  def self.get_progress_cache(book_id : String, username : String,
+                              entries : Array(Entry))
+    progress_cache_id = "#{book_id}:#{username}"
+    progress_cache_sig = Digest::SHA1.hexdigest (entries.map &.id).to_s
+    cached = @@progress_cache[progress_cache_id]?
+    if cached && cached[0] == progress_cache_sig
+      Logger.debug "Progress Cache Hit! #{progress_cache_id}"
+      return cached[1]
+    end
+  end
+
+  def self.invalidate_progress_cache(book_id : String, username : String)
+    progress_cache_id = "#{book_id}:#{username}"
+    if @@progress_cache[progress_cache_id]?
+      @@progress_cache.delete progress_cache_id
+      Logger.debug "Progress Invalidate Cache #{progress_cache_id}"
+    end
+  end
+
+  def self.move_progress_cache(book_id : String)
+    if @@progress_cache_previous[book_id]?
+      @@progress_cache_previous[book_id].each do |username, cached|
+        id = "#{book_id}:#{username}"
+        unless @@progress_cache[id]?
+          # It would be invalidated when entries changed
+          @@progress_cache[id] = cached
+        end
+      end
+    end
+  end
+
+  private def self.clear_progress_cache
+    @@progress_cache_previous = {} of String => Hash(String, ProgressCache)
+    @@progress_cache.each do |id, cached|
+      splitted = id.split(':', 2)
+      book_id = splitted[0]
+      username = splitted[1]
+      unless @@progress_cache_previous[book_id]?
+        @@progress_cache_previous[book_id] = {} of String => ProgressCache
+      end
+
+      @@progress_cache_previous[book_id][username] = cached
+    end
+    @@progress_cache = {} of String => ProgressCache
+  end
+
+  private def self.clean_progress_cache
+    @@progress_cache_previous = {} of String => Hash(String, ProgressCache)
+  end
+
+  # book.dir:username => SortOptions
+  @@cached_sort_opt = {} of String => SortOptions
+  @@cached_sort_opt_previous = {} of String => Hash(String, SortOptions)
+
+  def self.set_sort_opt(dir : String, username : String, sort_opt : SortOptions)
+    id = "#{dir}:#{username}"
+    @@cached_sort_opt[id] = sort_opt
+  end
+
+  def self.get_sort_opt(dir : String, username : String)
+    id = "#{dir}:#{username}"
+    @@cached_sort_opt[id]?
+  end
+
+  def self.invalidate_sort_opt(dir : String, username : String)
+    id = "#{dir}:#{username}"
+    @@cached_sort_opt.delete id
+  end
+
+  def self.move_sort_opt(dir : String)
+    if @@cached_sort_opt_previous[dir]?
+      @@cached_sort_opt_previous[dir].each do |username, cached|
+        id = "#{dir}:#{username}"
+        unless @@cached_sort_opt[id]?
+          @@cached_sort_opt[id] = cached
+        end
+      end
+    end
+  end
+
+  private def self.clear_sort_opt
+    @@cached_sort_opt_previous = {} of String => Hash(String, SortOptions)
+    @@cached_sort_opt.each do |id, cached|
+      splitted = id.split(':', 2)
+      book_dir = splitted[0]
+      username = splitted[1]
+      unless @@cached_sort_opt_previous[book_dir]?
+        @@cached_sort_opt_previous[book_dir] = {} of String => SortOptions
+      end
+      @@cached_sort_opt_previous[book_dir][username] = cached
+    end
+    @@cached_sort_opt = {} of String => SortOptions
+  end
+
+  private def self.clean_sort_opt
+    @@cached_sort_opt_previous = {} of String => Hash(String, SortOptions)
+  end
+end

--- a/src/library/cache.cr
+++ b/src/library/cache.cr
@@ -70,21 +70,6 @@ class SortedEntriesCacheEntry < CacheEntry(Array(String), Array(Entry))
   end
 end
 
-class SortOptionsCacheEntry < CacheEntry(Tuple(String, Bool), SortOptions)
-  def self.to_save_t(value : SortOptions)
-    value.to_tuple
-  end
-
-  def self.to_return_t(value : Tuple(String, Bool))
-    SortOptions.from_tuple value
-  end
-
-  def instance_size
-    instance_sizeof(SortOptionsCacheEntry) +
-      @value[0].instance_size
-  end
-end
-
 class String
   def instance_size
     instance_sizeof(String) + bytesize
@@ -105,18 +90,14 @@ struct Tuple(*T)
   end
 end
 
-alias CacheableType = Array(Entry) | String | Tuple(String, Int32) |
-                      SortOptions
+alias CacheableType = Array(Entry) | String | Tuple(String, Int32)
 alias CacheEntryType = SortedEntriesCacheEntry |
-                       SortOptionsCacheEntry |
                        CacheEntry(String, String) |
                        CacheEntry(Tuple(String, Int32), Tuple(String, Int32))
 
 def generate_cache_entry(key : String, value : CacheableType)
   if value.is_a? Array(Entry)
     SortedEntriesCacheEntry.new key, value
-  elsif value.is_a? SortOptions
-    SortOptionsCacheEntry.new key, value
   else
     CacheEntry(typeof(value), typeof(value)).new key, value
   end

--- a/src/library/cache.cr
+++ b/src/library/cache.cr
@@ -184,8 +184,8 @@ class SortedEntriesCache
 
   def self.init
     enabled = Config.current.sorted_entries_cache_enable
-    cache_size = Config.current.sorted_entries_cache_capacity_kbs
-    @@limit = Int128.new cache_size * 1024 if enabled
+    cache_size = Config.current.sorted_entries_cache_size_mbs
+    @@limit = Int128.new cache_size * 1024 * 1024 if enabled
   end
 
   def self.gen_key(book_id : String, username : String,

--- a/src/library/cache.cr
+++ b/src/library/cache.cr
@@ -1,164 +1,7 @@
 require "digest"
 
 require "./entry"
-
-class InfoCache
-  alias ProgressCache = Tuple(String, Int32)
-
-  def self.clear
-    clear_cover_url
-    clear_progress_cache
-    clear_sort_opt
-  end
-
-  def self.clean
-    clean_cover_url
-    clean_progress_cache
-    clean_sort_opt
-  end
-
-  # item id => cover_url
-  @@cached_cover_url = {} of String => String
-  @@cached_cover_url_previous = {} of String => String # item id => cover_url
-
-  def self.set_cover_url(id : String, cover_url : String)
-    @@cached_cover_url[id] = cover_url
-  end
-
-  def self.get_cover_url(id : String)
-    @@cached_cover_url[id]?
-  end
-
-  def self.invalidate_cover_url(id : String)
-    @@cached_cover_url.delete id
-  end
-
-  def self.move_cover_url(id : String)
-    if @@cached_cover_url_previous[id]?
-      @@cached_cover_url[id] = @@cached_cover_url_previous[id]
-    end
-  end
-
-  private def self.clear_cover_url
-    @@cached_cover_url_previous = @@cached_cover_url
-    @@cached_cover_url = {} of String => String
-  end
-
-  private def self.clean_cover_url
-    @@cached_cover_url_previous = {} of String => String
-  end
-
-  # book.id:username => {signature, sum}
-  @@progress_cache = {} of String => ProgressCache
-  # book.id => username => {signature, sum}
-  @@progress_cache_previous = {} of String => Hash(String, ProgressCache)
-
-  def self.set_progress_cache(book_id : String, username : String,
-                              entries : Array(Entry), sum : Int32)
-    progress_cache_id = "#{book_id}:#{username}"
-    progress_cache_sig = Digest::SHA1.hexdigest (entries.map &.id).to_s
-    @@progress_cache[progress_cache_id] = {progress_cache_sig, sum}
-    Logger.debug "Progress Cached #{progress_cache_id}"
-  end
-
-  def self.get_progress_cache(book_id : String, username : String,
-                              entries : Array(Entry))
-    progress_cache_id = "#{book_id}:#{username}"
-    progress_cache_sig = Digest::SHA1.hexdigest (entries.map &.id).to_s
-    cached = @@progress_cache[progress_cache_id]?
-    if cached && cached[0] == progress_cache_sig
-      Logger.debug "Progress Cache Hit! #{progress_cache_id}"
-      return cached[1]
-    end
-  end
-
-  def self.invalidate_progress_cache(book_id : String, username : String)
-    progress_cache_id = "#{book_id}:#{username}"
-    if @@progress_cache[progress_cache_id]?
-      @@progress_cache.delete progress_cache_id
-      Logger.debug "Progress Invalidate Cache #{progress_cache_id}"
-    end
-  end
-
-  def self.move_progress_cache(book_id : String)
-    if @@progress_cache_previous[book_id]?
-      @@progress_cache_previous[book_id].each do |username, cached|
-        id = "#{book_id}:#{username}"
-        unless @@progress_cache[id]?
-          # It would be invalidated when entries changed
-          @@progress_cache[id] = cached
-        end
-      end
-    end
-  end
-
-  private def self.clear_progress_cache
-    @@progress_cache_previous = {} of String => Hash(String, ProgressCache)
-    @@progress_cache.each do |id, cached|
-      splitted = id.split(':', 2)
-      book_id = splitted[0]
-      username = splitted[1]
-      unless @@progress_cache_previous[book_id]?
-        @@progress_cache_previous[book_id] = {} of String => ProgressCache
-      end
-
-      @@progress_cache_previous[book_id][username] = cached
-    end
-    @@progress_cache = {} of String => ProgressCache
-  end
-
-  private def self.clean_progress_cache
-    @@progress_cache_previous = {} of String => Hash(String, ProgressCache)
-  end
-
-  # book.dir:username => SortOptions
-  @@cached_sort_opt = {} of String => SortOptions
-  @@cached_sort_opt_previous = {} of String => Hash(String, SortOptions)
-
-  def self.set_sort_opt(dir : String, username : String, sort_opt : SortOptions)
-    id = "#{dir}:#{username}"
-    @@cached_sort_opt[id] = sort_opt
-  end
-
-  def self.get_sort_opt(dir : String, username : String)
-    id = "#{dir}:#{username}"
-    @@cached_sort_opt[id]?
-  end
-
-  def self.invalidate_sort_opt(dir : String, username : String)
-    id = "#{dir}:#{username}"
-    @@cached_sort_opt.delete id
-  end
-
-  def self.move_sort_opt(dir : String)
-    if @@cached_sort_opt_previous[dir]?
-      @@cached_sort_opt_previous[dir].each do |username, cached|
-        id = "#{dir}:#{username}"
-        unless @@cached_sort_opt[id]?
-          @@cached_sort_opt[id] = cached
-        end
-      end
-    end
-  end
-
-  private def self.clear_sort_opt
-    @@cached_sort_opt_previous = {} of String => Hash(String, SortOptions)
-    @@cached_sort_opt.each do |id, cached|
-      splitted = id.split(':', 2)
-      book_dir = splitted[0]
-      username = splitted[1]
-      unless @@cached_sort_opt_previous[book_dir]?
-        @@cached_sort_opt_previous[book_dir] = {} of String => SortOptions
-      end
-      @@cached_sort_opt_previous[book_dir][username] = cached
-    end
-    @@cached_sort_opt = {} of String => SortOptions
-  end
-
-  private def self.clean_sort_opt
-    @@cached_sort_opt_previous = {} of String => Hash(String, SortOptions)
-  end
-end
+require "./types"
 
 private class CacheEntry(SaveT, ReturnT)
   getter key : String, atime : Time
@@ -227,11 +70,45 @@ class SortedEntriesCacheEntry < CacheEntry(Array(String), Array(Entry))
   end
 end
 
-alias CacheEntryType = SortedEntriesCacheEntry
+class SortOptionsCacheEntry < CacheEntry(Tuple(String, Bool), SortOptions)
+  def self.to_save_t(value : SortOptions)
+    value.to_tuple
+  end
 
-def generate_cache_entry(key : String, value : Array(Entry) | Int32 | String)
+  def self.to_return_t(value : Tuple(String, Bool))
+    SortOptions.from_tuple value
+  end
+
+  def instance_size
+    instance_sizeof(SortOptionsCacheEntry) +
+      @value[0].instance_size
+  end
+end
+
+class String
+  def instance_size
+    instance_sizeof(String) + bytesize
+  end
+end
+
+struct Tuple(*T)
+  def instance_size
+    sizeof(T) # iterate T and add instance_size of that
+  end
+end
+
+alias CacheableType = Array(Entry) | String | Tuple(String, Int32) |
+                      SortOptions
+alias CacheEntryType = SortedEntriesCacheEntry |
+                       SortOptionsCacheEntry |
+                       CacheEntry(String, String) |
+                       CacheEntry(Tuple(String, Int32), Tuple(String, Int32))
+
+def generate_cache_entry(key : String, value : CacheableType)
   if value.is_a? Array(Entry)
     SortedEntriesCacheEntry.new key, value
+  elsif value.is_a? SortOptions
+    SortOptionsCacheEntry.new key, value
   else
     CacheEntry(typeof(value), typeof(value)).new key, value
   end

--- a/src/library/cache.cr
+++ b/src/library/cache.cr
@@ -171,8 +171,10 @@ private class SortedEntriesCacheEntry
   end
 
   def instance_size
-    @value.size * (instance_sizeof(String) + sizeof(String)) +
-      @value.sum(&.size) + instance_sizeof(SortedEntriesCacheEntry)
+    instance_sizeof(SortedEntriesCacheEntry) + # sizeof itself
+      instance_sizeof(String) + @key.bytesize + # allocated memory for @key
+      @value.size * (instance_sizeof(String) + sizeof(String)) +
+      @value.sum(&.bytesize) # elements in Array(String)
   end
 end
 

--- a/src/library/cache.cr
+++ b/src/library/cache.cr
@@ -63,10 +63,11 @@ class SortedEntriesCacheEntry < CacheEntry(Array(String), Array(Entry))
 
   def self.gen_key(book_id : String, username : String,
                    entries : Array(Entry), opt : SortOptions?)
-    sig = Digest::SHA1.hexdigest (entries.map &.id).to_s
+    entries_sig = Digest::SHA1.hexdigest (entries.map &.id).to_s
     user_context = opt && opt.method == SortMethod::Progress ? username : ""
-    Digest::SHA1.hexdigest (book_id + sig + user_context +
-                            (opt ? opt.to_tuple.to_s : "nil"))
+    sig = Digest::SHA1.hexdigest (book_id + entries_sig + user_context +
+                                  (opt ? opt.to_tuple.to_s : "nil"))
+    "#{sig}:sorted_entries"
   end
 end
 

--- a/src/library/cache.cr
+++ b/src/library/cache.cr
@@ -3,6 +3,16 @@ require "digest"
 require "./entry"
 require "./types"
 
+# Base class for an entry in the LRU cache.
+# There are two ways to use it:
+#   1. Use it as it is by instantiating with the appropriate `SaveT` and
+#     `ReturnT`. Note that in this case, `SaveT` and `ReturnT` must be the
+#     same type. That is, the input value will be stored as it is without
+#     any transformation.
+#   2. You can also subclass it and provide custom implementations for
+#     `to_save_t` and `to_return_t`. This allows you to transform and store
+#     the input value to a different type. See `SortedEntriesCacheEntry` as
+#     an example.
 private class CacheEntry(SaveT, ReturnT)
   getter key : String, atime : Time
 

--- a/src/library/cache.cr
+++ b/src/library/cache.cr
@@ -39,10 +39,10 @@ class SortedEntriesCacheEntry < CacheEntry(Array(String), Array(Entry))
   end
 
   def self.to_return_t(value : Array(String))
-    ids2entries value
+    ids_to_entries value
   end
 
-  private def self.ids2entries(ids : Array(String))
+  private def self.ids_to_entries(ids : Array(String))
     e_map = Library.default.deep_entries.to_h { |entry| {entry.id, entry} }
     entries = [] of Entry
     begin

--- a/src/library/cache.cr
+++ b/src/library/cache.cr
@@ -93,7 +93,15 @@ end
 
 struct Tuple(*T)
   def instance_size
-    sizeof(T) # iterate T and add instance_size of that
+    sizeof(T) + # total size of non-reference types
+      self.sum do |e|
+        next 0 unless e.is_a? Reference
+        if e.responds_to? :instance_size
+          e.instance_size
+        else
+          instance_sizeof(typeof(e))
+        end
+      end
   end
 end
 

--- a/src/library/cache.cr
+++ b/src/library/cache.cr
@@ -120,13 +120,17 @@ class LRUCache
   # key => entry
   @@cache = {} of String => CacheEntryType
 
+  def self.enabled
+    Config.current.sorted_entries_cache_enable
+  end
+
   def self.init
-    enabled = Config.current.sorted_entries_cache_enable
     cache_size = Config.current.sorted_entries_cache_size_mbs
     @@limit = Int128.new cache_size * 1024 * 1024 if enabled
   end
 
   def self.get(key : String)
+    return unless enabled
     entry = @@cache[key]?
     Logger.debug "LRUCache Cache Hit! #{key}" unless entry.nil?
     Logger.debug "LRUCache Cache Miss #{key}" if entry.nil?
@@ -134,6 +138,7 @@ class LRUCache
   end
 
   def self.set(cache_entry : CacheEntryType)
+    return unless enabled
     key = cache_entry.key
     @@cache[key] = cache_entry
     Logger.debug "LRUCache Cached #{key}"
@@ -141,6 +146,7 @@ class LRUCache
   end
 
   def self.invalidate(key : String)
+    return unless enabled
     @@cache.delete key
   end
 
@@ -149,7 +155,7 @@ class LRUCache
     Logger.debug "---- LRU Cache ----"
     Logger.debug "Size: #{sum} Bytes"
     Logger.debug "List:"
-    @@cache.each { |k, v| Logger.debug "#{k} | #{v.atime}" }
+    @@cache.each { |k, v| Logger.debug "#{k} | #{v.atime} | #{v.instance_size}" }
     Logger.debug "-------------------"
   end
 

--- a/src/library/cache.cr
+++ b/src/library/cache.cr
@@ -238,7 +238,7 @@ def generate_cache_entry(key : String, value : Array(Entry) | Int32 | String)
 end
 
 # LRU Cache
-class SortedEntriesCache
+class LRUCache
   @@limit : Int128 = Int128.new 0
   # key => entry
   @@cache = {} of String => CacheEntryType

--- a/src/library/cache.cr
+++ b/src/library/cache.cr
@@ -155,7 +155,9 @@ class LRUCache
     Logger.debug "---- LRU Cache ----"
     Logger.debug "Size: #{sum} Bytes"
     Logger.debug "List:"
-    @@cache.each { |k, v| Logger.debug "#{k} | #{v.atime} | #{v.instance_size}" }
+    @@cache.each do |k, v|
+      Logger.debug "#{k} | #{v.atime} | #{v.instance_size}"
+    end
     Logger.debug "-------------------"
   end
 

--- a/src/library/cache.cr
+++ b/src/library/cache.cr
@@ -178,9 +178,15 @@ end
 
 # LRU Cache
 class SortedEntriesCache
-  @@limit : Int128 = Int128.new 1024 * 1024 * 50 # 50MB
+  @@limit : Int128 = Int128.new 0
   # key => entry
   @@cache = {} of String => SortedEntriesCacheEntry
+
+  def self.init
+    enabled = Config.current.sorted_entries_cache_enable
+    cache_size = Config.current.sorted_entries_cache_capacity_kbs
+    @@limit = Int128.new cache_size * 1024 if enabled
+  end
 
   def self.gen_key(book_id : String, username : String,
                    entries : Array(Entry), opt : SortOptions?)

--- a/src/library/cache.cr
+++ b/src/library/cache.cr
@@ -161,7 +161,9 @@ class LRUCache
   end
 
   private def self.remove_least_recent_access
-    Logger.debug "Removing entries from LRUCache" if @@should_log
+    if @@should_log && is_cache_full
+      Logger.debug "Removing entries from LRUCache"
+    end
     while is_cache_full && @@cache.size > 0
       min_tuple = @@cache.min_by { |_, entry| entry.atime }
       min_key = min_tuple[0]

--- a/src/library/entry.cr
+++ b/src/library/entry.cr
@@ -187,6 +187,11 @@ class Entry
     @book.parents.each do |parent|
       InfoCache.invalidate_progress_cache parent.id, username
     end
+    [false, true].each do |ascend|
+      sorted_entries_cache_key = SortedEntriesCache.gen_key @book.id, username,
+        @book.entries, SortOptions.new(SortMethod::Progress, ascend)
+      SortedEntriesCache.invalidate sorted_entries_cache_key
+    end
 
     TitleInfo.new @book.dir do |info|
       if info.progress[username]?.nil?

--- a/src/library/entry.cr
+++ b/src/library/entry.cr
@@ -190,7 +190,7 @@ class Entry
     [false, true].each do |ascend|
       sorted_entries_cache_key = SortedEntriesCacheEntry.gen_key @book.id,
         username, @book.entries, SortOptions.new(SortMethod::Progress, ascend)
-      SortedEntriesCache.invalidate sorted_entries_cache_key
+      LRUCache.invalidate sorted_entries_cache_key
     end
 
     TitleInfo.new @book.dir do |info|

--- a/src/library/entry.cr
+++ b/src/library/entry.cr
@@ -81,8 +81,6 @@ class Entry
 
   def cover_url
     return "#{Config.current.base_url}img/icon.png" if @err_msg
-    cached_cover_url = LRUCache.get "#{@id}:cover_url"
-    return cached_cover_url if cached_cover_url.is_a? String
 
     unless @book.entry_cover_url_cache
       TitleInfo.new @book.dir do |info|
@@ -98,7 +96,6 @@ class Entry
         url = File.join Config.current.base_url, info_url
       end
     end
-    LRUCache.set generate_cache_entry "#{@id}:cover_url", url
     url
   end
 

--- a/src/library/entry.cr
+++ b/src/library/entry.cr
@@ -81,9 +81,17 @@ class Entry
 
   def cover_url
     return "#{Config.current.base_url}img/icon.png" if @err_msg
+
+    unless @book.entry_cover_url_cache
+      TitleInfo.new @book.dir do |info|
+        @book.entry_cover_url_cache = info.entry_cover_url
+      end
+    end
+    entry_cover_url = @book.entry_cover_url_cache
+
     url = "#{Config.current.base_url}api/cover/#{@book.id}/#{@id}"
-    TitleInfo.new @book.dir do |info|
-      info_url = info.entry_cover_url[@title]?
+    if entry_cover_url
+      info_url = entry_cover_url[@title]?
       unless info_url.nil? || info_url.empty?
         url = File.join Config.current.base_url, info_url
       end

--- a/src/library/entry.cr
+++ b/src/library/entry.cr
@@ -188,8 +188,8 @@ class Entry
       InfoCache.invalidate_progress_cache parent.id, username
     end
     [false, true].each do |ascend|
-      sorted_entries_cache_key = SortedEntriesCache.gen_key @book.id, username,
-        @book.entries, SortOptions.new(SortMethod::Progress, ascend)
+      sorted_entries_cache_key = SortedEntriesCacheEntry.gen_key @book.id,
+        username, @book.entries, SortOptions.new(SortMethod::Progress, ascend)
       SortedEntriesCache.invalidate sorted_entries_cache_key
     end
 

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -106,8 +106,6 @@ class Library
 
     storage = Storage.new auto_close: false
 
-    InfoCache.clear
-
     (Dir.entries @dir)
       .select { |fn| !fn.starts_with? "." }
       .map { |fn| File.join @dir, fn }
@@ -120,8 +118,6 @@ class Library
         @title_hash[title.id] = title
         @title_ids << title.id
       end
-
-    InfoCache.clean
 
     storage.bulk_insert_ids
     storage.close

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -102,6 +102,8 @@ class Library
 
     storage = Storage.new auto_close: false
 
+    InfoCache.clear
+
     (Dir.entries @dir)
       .select { |fn| !fn.starts_with? "." }
       .map { |fn| File.join @dir, fn }
@@ -114,6 +116,8 @@ class Library
         @title_hash[title.id] = title
         @title_ids << title.id
       end
+
+    InfoCache.clean
 
     storage.bulk_insert_ids
     storage.close

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -51,11 +51,6 @@ class Library
   def sorted_titles(username, opt : SortOptions? = nil)
     if opt.nil?
       opt = SortOptions.from_info_json @dir, username
-    else
-      TitleInfo.new @dir do |info|
-        info.sort_by[username] = opt.to_tuple
-        info.save
-      end
     end
 
     # Helper function from src/util/util.cr

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -61,6 +61,10 @@ class Library
     titles + titles.flat_map &.deep_titles
   end
 
+  def deep_entries
+    titles.flat_map &.deep_entries
+  end
+
   def to_slim_json : String
     JSON.build do |json|
       json.object do

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -346,7 +346,7 @@ class Title
   def sorted_entries(username, opt : SortOptions? = nil)
     cache_key = SortedEntriesCacheEntry.gen_key @id, username, @entries, opt
     cached_entries = SortedEntriesCache.get cache_key
-    return cached_entries if cached_entries
+    return cached_entries if cached_entries.is_a? Array(Entry)
 
     if opt.nil?
       opt = SortOptions.from_info_json @dir, username
@@ -382,7 +382,7 @@ class Title
     ary.reverse! unless opt.not_nil!.ascend
 
     if Config.current.sorted_entries_cache_enable
-      SortedEntriesCache.set cache_key, ary
+      SortedEntriesCache.set generate_cache_entry cache_key, ary
     end
     ary
   end

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -379,9 +379,7 @@ class Title
 
     ary.reverse! unless opt.not_nil!.ascend
 
-    if Config.current.sorted_entries_cache_enable
-      LRUCache.set generate_cache_entry cache_key, ary
-    end
+    LRUCache.set generate_cache_entry cache_key, ary
     ary
   end
 

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -3,9 +3,12 @@ require "../archive"
 class Title
   getter dir : String, parent_id : String, title_ids : Array(String),
     entries : Array(Entry), title : String, id : String,
-    encoded_title : String, mtime : Time, signature : UInt64
+    encoded_title : String, mtime : Time, signature : UInt64,
+    entry_cover_url_cache : Hash(String, String)?
+  setter entry_cover_url_cache : Hash(String, String)?
 
   @entry_display_name_cache : Hash(String, String)?
+  @entry_cover_url_cache : Hash(String, String)?
 
   def initialize(@dir : String, @parent_id)
     storage = Storage.default

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -215,7 +215,7 @@ class Title
   end
 
   def set_display_name(dn)
-    @cached_display_name = nil
+    @cached_display_name = dn
     TitleInfo.new @dir do |info|
       info.display_name = dn
       info.save
@@ -250,6 +250,7 @@ class Title
   end
 
   def set_cover_url(url : String)
+    @cached_cover_url = url
     TitleInfo.new @dir do |info|
       info.cover_url = url
       info.save

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -9,6 +9,7 @@ class Title
 
   @entry_display_name_cache : Hash(String, String)?
   @entry_cover_url_cache : Hash(String, String)?
+  @cached_display_name : String?
 
   def initialize(@dir : String, @parent_id)
     storage = Storage.default
@@ -180,11 +181,15 @@ class Title
   end
 
   def display_name
+    cached_display_name = @cached_display_name
+    return cached_display_name unless cached_display_name.nil?
+
     dn = @title
     TitleInfo.new @dir do |info|
       info_dn = info.display_name
       dn = info_dn unless info_dn.empty?
     end
+    @cached_display_name = dn
     dn
   end
 
@@ -208,6 +213,7 @@ class Title
   end
 
   def set_display_name(dn)
+    @cached_display_name = nil
     TitleInfo.new @dir do |info|
       info.display_name = dn
       info.save
@@ -217,6 +223,7 @@ class Title
   def set_display_name(entry_name : String, dn)
     TitleInfo.new @dir do |info|
       info.entry_display_name[entry_name] = dn
+      @entry_display_name_cache = info.entry_display_name
       info.save
     end
   end

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -381,7 +381,9 @@ class Title
 
     ary.reverse! unless opt.not_nil!.ascend
 
-    SortedEntriesCache.set cache_key, ary
+    if Config.current.sorted_entries_cache_enable
+      SortedEntriesCache.set cache_key, ary
+    end
     ary
   end
 

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -259,6 +259,7 @@ class Title
   def set_cover_url(entry_name : String, url : String)
     TitleInfo.new @dir do |info|
       info.entry_cover_url[entry_name] = url
+      @entry_cover_url_cache = info.entry_cover_url
       info.save
     end
   end

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -345,7 +345,7 @@ class Title
   # When `opt` is not nil, it saves the options to info.json
   def sorted_entries(username, opt : SortOptions? = nil)
     cache_key = SortedEntriesCacheEntry.gen_key @id, username, @entries, opt
-    cached_entries = SortedEntriesCache.get cache_key
+    cached_entries = LRUCache.get cache_key
     return cached_entries if cached_entries.is_a? Array(Entry)
 
     if opt.nil?
@@ -382,7 +382,7 @@ class Title
     ary.reverse! unless opt.not_nil!.ascend
 
     if Config.current.sorted_entries_cache_enable
-      SortedEntriesCache.set generate_cache_entry cache_key, ary
+      LRUCache.set generate_cache_entry cache_key, ary
     end
     ary
   end
@@ -453,7 +453,7 @@ class Title
       sorted_entries_cache_key =
         SortedEntriesCacheEntry.gen_key @id, username, @entries,
           SortOptions.new(SortMethod::Progress, ascend)
-      SortedEntriesCache.invalidate sorted_entries_cache_key
+      LRUCache.invalidate sorted_entries_cache_key
     end
 
     selected_entries = ids

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -1,3 +1,4 @@
+require "digest"
 require "../archive"
 
 class Title
@@ -329,11 +330,6 @@ class Title
   def sorted_entries(username, opt : SortOptions? = nil)
     if opt.nil?
       opt = SortOptions.from_info_json @dir, username
-    else
-      TitleInfo.new @dir do |info|
-        info.sort_by[username] = opt.to_tuple
-        info.save
-      end
     end
 
     case opt.not_nil!.method

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -344,7 +344,7 @@ class Title
   #   use the default (auto, ascending)
   # When `opt` is not nil, it saves the options to info.json
   def sorted_entries(username, opt : SortOptions? = nil)
-    cache_key = SortedEntriesCache.gen_key @id, username, @entries, opt
+    cache_key = SortedEntriesCacheEntry.gen_key @id, username, @entries, opt
     cached_entries = SortedEntriesCache.get cache_key
     return cached_entries if cached_entries
 
@@ -451,7 +451,7 @@ class Title
     end
     [false, true].each do |ascend|
       sorted_entries_cache_key =
-        SortedEntriesCache.gen_key @id, username, @entries,
+        SortedEntriesCacheEntry.gen_key @id, username, @entries,
           SortOptions.new(SortMethod::Progress, ascend)
       SortedEntriesCache.invalidate sorted_entries_cache_key
     end

--- a/src/library/types.cr
+++ b/src/library/types.cr
@@ -35,16 +35,12 @@ class SortOptions
   end
 
   def self.from_info_json(dir, username)
-    key = "#{dir}:#{username}:sort_opt"
-    cached_opt = LRUCache.get key
-    return cached_opt if cached_opt.is_a? SortOptions
     opt = SortOptions.new
     TitleInfo.new dir do |info|
       if info.sort_by.has_key? username
         opt = SortOptions.from_tuple info.sort_by[username]
       end
     end
-    LRUCache.set generate_cache_entry key, opt
     opt
   end
 

--- a/src/library/types.cr
+++ b/src/library/types.cr
@@ -35,15 +35,16 @@ class SortOptions
   end
 
   def self.from_info_json(dir, username)
-    cached_opt = InfoCache.get_sort_opt dir, username
-    return cached_opt if cached_opt
+    key = "#{dir}:#{username}:sort_opt"
+    cached_opt = LRUCache.get key
+    return cached_opt if cached_opt.is_a? SortOptions
     opt = SortOptions.new
     TitleInfo.new dir do |info|
       if info.sort_by.has_key? username
         opt = SortOptions.from_tuple info.sort_by[username]
       end
     end
-    InfoCache.set_sort_opt dir, username, opt
+    LRUCache.set generate_cache_entry key, opt
     opt
   end
 

--- a/src/library/types.cr
+++ b/src/library/types.cr
@@ -35,12 +35,15 @@ class SortOptions
   end
 
   def self.from_info_json(dir, username)
+    cached_opt = InfoCache.get_sort_opt dir, username
+    return cached_opt if cached_opt
     opt = SortOptions.new
     TitleInfo.new dir do |info|
       if info.sort_by.has_key? username
         opt = SortOptions.from_tuple info.sort_by[username]
       end
     end
+    InfoCache.set_sort_opt dir, username, opt
     opt
   end
 

--- a/src/mango.cr
+++ b/src/mango.cr
@@ -55,7 +55,7 @@ class CLI < Clim
       Config.load(opts.config).set_current
 
       # Initialize main components
-      SortedEntriesCache.init
+      LRUCache.init
       Storage.default
       Queue.default
       Library.default

--- a/src/mango.cr
+++ b/src/mango.cr
@@ -55,6 +55,7 @@ class CLI < Clim
       Config.load(opts.config).set_current
 
       # Initialize main components
+      SortedEntriesCache.init
       Storage.default
       Queue.default
       Library.default

--- a/src/routes/main.cr
+++ b/src/routes/main.cr
@@ -41,7 +41,7 @@ struct MainRouter
         username = get_username env
 
         sort_opt = SortOptions.from_info_json Library.default.dir, username
-        get_sort_opt
+        get_and_save_sort_opt Library.default.dir
 
         titles = Library.default.sorted_titles username, sort_opt
         percentage = titles.map &.load_percentage username
@@ -59,12 +59,12 @@ struct MainRouter
         username = get_username env
 
         sort_opt = SortOptions.from_info_json title.dir, username
-        get_sort_opt
+        get_and_save_sort_opt title.dir
 
         entries = title.sorted_entries username, sort_opt
-
         percentage = title.load_percentage_for_all_entries username, sort_opt
         title_percentage = title.titles.map &.load_percentage username
+
         layout "title"
       rescue e
         Logger.error e

--- a/src/util/web.cr
+++ b/src/util/web.cr
@@ -120,7 +120,6 @@ macro get_and_save_sort_opt(dir)
 
     sort_opt = SortOptions.new sort_method, is_ascending
 
-    key = "#{{{dir}}}:#{username}:sort_opt"
     TitleInfo.new {{dir}} do |info|
       info.sort_by[username] = sort_opt.to_tuple
       info.save

--- a/src/util/web.cr
+++ b/src/util/web.cr
@@ -121,7 +121,6 @@ macro get_and_save_sort_opt(dir)
     sort_opt = SortOptions.new sort_method, is_ascending
 
     key = "#{{{dir}}}:#{username}:sort_opt"
-    LRUCache.set generate_cache_entry key, sort_opt
     TitleInfo.new {{dir}} do |info|
       info.sort_by[username] = sort_opt.to_tuple
       info.save

--- a/src/util/web.cr
+++ b/src/util/web.cr
@@ -120,7 +120,8 @@ macro get_and_save_sort_opt(dir)
 
     sort_opt = SortOptions.new sort_method, is_ascending
 
-    InfoCache.set_sort_opt {{dir}}, username, sort_opt
+    key = "#{{{dir}}}:#{username}:sort_opt"
+    LRUCache.set generate_cache_entry key, sort_opt
     TitleInfo.new {{dir}} do |info|
       info.sort_by[username] = sort_opt.to_tuple
       info.save

--- a/src/util/web.cr
+++ b/src/util/web.cr
@@ -107,6 +107,26 @@ macro get_sort_opt
   end
 end
 
+macro get_and_save_sort_opt(dir)
+  sort_method = env.params.query["sort"]?
+
+  if sort_method
+    is_ascending = true
+
+    ascend = env.params.query["ascend"]?
+    if ascend && ascend.to_i? == 0
+      is_ascending = false
+    end
+
+    sort_opt = SortOptions.new sort_method, is_ascending
+
+    TitleInfo.new {{dir}} do |info|
+      info.sort_by[username] = sort_opt.to_tuple
+      info.save
+    end
+  end
+end
+
 module HTTP
   class Client
     private def self.exec(uri : URI, tls : TLSContext = nil)

--- a/src/util/web.cr
+++ b/src/util/web.cr
@@ -120,6 +120,7 @@ macro get_and_save_sort_opt(dir)
 
     sort_opt = SortOptions.new sort_method, is_ascending
 
+    InfoCache.set_sort_opt {{dir}}, username, sort_opt
     TitleInfo.new {{dir}} do |info|
       info.sort_by[username] = sort_opt.to_tuple
       info.save


### PR DESCRIPTION
## Implementations

To improve page loading, I cached lots of data. The principles are:

* Avoid accessing `info.json` files
* Reuse results of method that called many times with same arguments

### Misc.

#### cache entry_cover_url

Like `entry_display_name`, cached `entry_cover_url` would improve rendering `src/views/components/card.html.ecr`. This is very effective.

#### cache `display_name` of title

This would avoid to access `info.json`

#### change where sort opt are saved

It's okay that sort options are saved when accessing library, book with parameters. I removed unnecessary actions. This would avoid to access `info.json`

### Caching Library

This utility implemented at `cache.cr` helps cached data to be preserved after scanning.
This caches:

* `cover_url` of each entry
* results of `deep_read_page_count` of each title
* sort options from `info.json` files

I think the second one is quite effective.

### Sorted Entries Cache

There are lots of calls `sorted_entries`, which takes long (222 entries took 80ms on my machine). Besides it called three times with the same arguments when accessing title page. Caching them is effective since they are not changed until modifying entries. Currently, this option is not enabled as default. You should set the flag true for enabling. And the cache size option doesn't guarantee the machine to consume memory precisely.

## Effectiveness

### Test environment

I loaded a title page that has 222 entries (no nested title, about 11GB) on SATA3 SSD. I'm sorry that I have tested them only once

### As is

first access: took 1140ms

![image](https://user-images.githubusercontent.com/6760150/131363508-eb3a25b0-c64d-4b2b-890b-3a11062e5305.png)

second access: 1119ms (not changed)

![image](https://user-images.githubusercontent.com/6760150/131363638-8f113996-9f5d-4a1f-b83c-6ed6f8c4217e.png)

took long, almost same time

### With only caching entries' cover url

first access: 700ms (x1.6 faster)

![image](https://user-images.githubusercontent.com/6760150/131364435-04e564c3-896d-46aa-b647-f89190d3a524.png)

second access: 735ms

![image](https://user-images.githubusercontent.com/6760150/131364476-5f9f91dd-3f58-4360-8502-82ceb0ee7116.png)

### With full implementation except sorted entries cache

first access: took 233ms  (x4.9 faster)

![image](https://user-images.githubusercontent.com/6760150/131364841-a64d4f1e-9d8c-425d-bc0f-4f47f49c633e.png)

second access: took 238ms

![image](https://user-images.githubusercontent.com/6760150/131364928-d64563be-cd0e-4d92-b63f-ba8f2e4125b5.png)

### With full implementation

first access: took 115ms (x10 faster)

![image](https://user-images.githubusercontent.com/6760150/131363000-b994a60c-f34b-4455-8899-429fbeafd82a.png)

second access: took 50ms (even faster)

![image](https://user-images.githubusercontent.com/6760150/131363042-adf5150b-eab3-45dc-aaba-7157a2fea521.png)

-----

This resolve #186 partly.