### PR TITLE
Stricter sanitization rules for download filenames

### DIFF
--- a/spec/util_spec.cr
+++ b/spec/util_spec.cr
@@ -61,3 +61,13 @@ describe "chapter_sort" do
     end.should eq ary
   end
 end
+
+describe "sanitize_filename" do
+  it "returns a random string for empty sanitized string" do
+    sanitize_filename("..").should_not eq sanitize_filename("..")
+  end
+  it "sanitizes correctly" do
+    sanitize_filename("..  \n\v.\rマンゴー/|*()<[1/2] 3.14 hello world ")
+      .should eq " . マンゴー_()[1_2] 3.14 hello world"
+  end
+end

--- a/spec/util_spec.cr
+++ b/spec/util_spec.cr
@@ -68,6 +68,6 @@ describe "sanitize_filename" do
   end
   it "sanitizes correctly" do
     sanitize_filename("..  \n\v.\rマンゴー/|*()<[1/2] 3.14 hello world ")
-      .should eq " . マンゴー_()[1_2] 3.14 hello world"
+      .should eq "マンゴー_()[1_2] 3.14 hello world"
   end
 end

--- a/src/plugin/downloader.cr
+++ b/src/plugin/downloader.cr
@@ -23,12 +23,6 @@ class Plugin
       job
     end
 
-    private def process_filename(str)
-      str
-        .gsub(/[\/\s\.\177\000-\031]/, "_")
-        .gsub(/__+/, "_")
-    end
-
     private def download(job : Queue::Job)
       @downloading = true
       @queue.set_status Queue::JobStatus::Downloading, job
@@ -43,8 +37,8 @@ class Plugin
 
         pages = info["pages"].as_i
 
-        manga_title = process_filename job.manga_title
-        chapter_title = process_filename info["title"].as_s
+        manga_title = sanitize_filename job.manga_title
+        chapter_title = sanitize_filename info["title"].as_s
 
         @queue.set_pages pages, job
         lib_dir = @library_path
@@ -69,7 +63,7 @@ class Plugin
       while page = plugin.next_page
         break unless @queue.exists? job
 
-        fn = process_filename page["filename"].as_s
+        fn = sanitize_filename page["filename"].as_s
         url = page["url"].as_s
         headers = HTTP::Headers.new
 

--- a/src/plugin/downloader.cr
+++ b/src/plugin/downloader.cr
@@ -24,8 +24,9 @@ class Plugin
     end
 
     private def process_filename(str)
-      return "_" if str == ".."
-      str.gsub "/", "_"
+      str
+        .gsub(/[\/\s\.\177\000-\031]/, "_")
+        .gsub(/__+/, "_")
     end
 
     private def download(job : Queue::Job)

--- a/src/util/util.cr
+++ b/src/util/util.cr
@@ -135,7 +135,7 @@ def sanitize_filename(str : String) : String
     .gsub(/\s+/, " ")
     .strip
     .gsub(/\//, "_")
-    .gsub(/^\.+/, "")
+    .gsub(/^[\.\s]+/, "")
     .gsub(/[\177\000-\031\\:\*\?\"<>\|]/, "")
   sanitized.size > 0 ? sanitized : random_str
 end

--- a/src/util/util.cr
+++ b/src/util/util.cr
@@ -120,3 +120,22 @@ class String
     match / s.size
   end
 end
+
+# Does the followings:
+#   - turns space-like characters into the normal whitespaces ( )
+#   - strips and collapses spaces
+#   - removes ASCII control characters
+#   - replaces slashes (/) with underscores (_)
+#   - removes leading dots (.)
+#   - removes the following special characters: \:*?"<>|
+#
+# If the sanitized string is empty, returns a random string instead.
+def sanitize_filename(str : String) : String
+  sanitized = str
+    .gsub(/\s+/, " ")
+    .strip
+    .gsub(/\//, "_")
+    .gsub(/^\.+/, "")
+    .gsub(/[\177\000-\031\\:\*\?\"<>\|]/, "")
+  sanitized.size > 0 ? sanitized : random_str
+end


### PR DESCRIPTION
Fixes #212.

This PR adds a new utility function `sanitize_filename` as follows

https://github.com/hkalexling/Mango/blob/ccf558eaa7657a96ebe7277828ad7fdf6397fc9a/src/util/util.cr#L124-L141

Unit tests included:

https://github.com/hkalexling/Mango/blob/ccf558eaa7657a96ebe7277828ad7fdf6397fc9a/spec/util_spec.cr#L65-L73