### PR TITLE
Reuse scanned titles on boot and scanning

### DIFF
--- a/src/config.cr
+++ b/src/config.cr
@@ -23,6 +23,7 @@ class Config
   property cache_enabled = false
   property cache_size_mbs = 50
   property cache_log_enabled = true
+  property forcely_yield_count = 1000
   property disable_login = false
   property default_username = ""
   property auth_proxy_header_name = ""

--- a/src/library/entry.cr
+++ b/src/library/entry.cr
@@ -1,4 +1,5 @@
 require "image_size"
+require "yaml"
 
 class Entry
   include YAML::Serializable

--- a/src/library/entry.cr
+++ b/src/library/entry.cr
@@ -1,6 +1,8 @@
 require "image_size"
 
 class Entry
+  include YAML::Serializable
+
   getter zip_path : String, book : Title, title : String,
     size : String, pages : Int32, id : String, encoded_path : String,
     encoded_title : String, mtime : Time, err_msg : String?

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -44,19 +44,11 @@ class Library
     zip_file.close
 
     if is_loaded
-      spawn do
-        start = Time.local
-        Library.default.scan
-        ms = (Time.local - start).total_milliseconds
-        Logger.info "Re-scanned #{Library.default.title_ids.size} titles \
-          in #{ms}ms"
-      end
+      Library.default.register_jobs
     end
   end
 
   def initialize
-    register_mime_types
-
     @dir = Config.current.library_path
     # explicitly initialize @titles to bypass the compiler check. it will
     #   be filled with actual Titles in the `scan` call below
@@ -65,6 +57,12 @@ class Library
 
     @entries_count = 0
     @thumbnails_count = 0
+
+    register_jobs
+  end
+
+  protected def register_jobs
+    register_mime_types
 
     scan_interval = Config.current.scan_interval_minutes
     if scan_interval < 1

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -8,7 +8,7 @@ class Library
 
   def save_instance
     path = Config.current.library_path
-    instance_file_path = File.join path, "library.yml.zip"
+    instance_file_path = File.join path, "library.yml.gz"
 
     writer = Compress::Gzip::Writer.new instance_file_path,
       Compress::Gzip::BEST_COMPRESSION
@@ -19,7 +19,7 @@ class Library
   def self.load_instance
     dir = Config.current.library_path
     return unless Dir.exists? dir
-    instance_file_path = File.join dir, "library.yml.zip"
+    instance_file_path = File.join dir, "library.yml.gz"
     return unless File.exists? instance_file_path
 
     Logger.debug "Load library instance"

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -152,7 +152,10 @@ class Library
     @title_ids.select! do |title_id|
       title = @title_hash[title_id]
       existence = title.examine examine_context
-      @title_hash.delete title_id unless existence
+      unless existence
+        @title_hash.delete title_id
+        examine_context["deleted_title_ids"] << title_id
+      end
       existence
     end
     remained_title_dirs = @title_ids.map { |id| title_hash[id].dir }

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -143,10 +143,10 @@ class Library
     storage = Storage.new auto_close: false
 
     examine_context : ExamineContext = {
-      file_count: 0,
+      file_counter:              (YieldCounter.new 1000),
       cached_contents_signature: {} of String => String,
-      deleted_title_ids: [] of String,
-      deleted_entry_ids: [] of String
+      deleted_title_ids:         [] of String,
+      deleted_entry_ids:         [] of String,
     }
 
     @title_ids.select! do |title_id|

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -1,4 +1,6 @@
 class Library
+  include YAML::Serializable
+
   getter dir : String, title_ids : Array(String),
     title_hash : Hash(String, Title)
 

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -23,7 +23,9 @@ class Library
 
     Logger.debug "Load library instance"
     zip_file = Compress::Zip::File.new instance_file_path
-    instance_file = zip_file.entries.find { |entry| entry.filename == "instance.yml" }
+    instance_file = zip_file.entries.find do |entry|
+      entry.filename == "instance.yml"
+    end
 
     if instance_file.nil?
       zip_file.close

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -159,7 +159,9 @@ class Library
 
     @title_ids.select! do |title_id|
       title = @title_hash[title_id]
-      title.examine
+      existence = title.examine
+      @title_hash.delete title_id unless existence
+      existence
     end
     remained_title_dirs = @title_ids.map { |id| title_hash[id].dir }
 

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -153,13 +153,15 @@ class Library
       title = @title_hash[title_id]
       existence = title.examine examine_context
       unless existence
-        examine_context["deleted_title_ids"].concat title.deep_titles.map &.id
+        examine_context["deleted_title_ids"].concat [title_id] + title.deep_titles.map &.id
         examine_context["deleted_entry_ids"].concat title.deep_entries.map &.id
-        @title_hash.delete title_id
       end
       existence
     end
     remained_title_dirs = @title_ids.map { |id| title_hash[id].dir }
+    examine_context["deleted_title_ids"].each do |title_id|
+      @title_hash.delete title_id
+    end
 
     cache = examine_context["cached_contents_signature"]
     (Dir.entries @dir)

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -21,6 +21,7 @@ class Library
     instance_file_path = File.join dir, "library.yml.zip"
     return unless File.exists? instance_file_path
 
+    Logger.debug "Load library instance"
     zip_file = Compress::Zip::File.new instance_file_path
     instance_file = zip_file.entries.find { |entry| entry.filename == "instance.yml" }
 
@@ -38,7 +39,13 @@ class Library
 
     zip_file.close
 
-    Library.default.scan
+    spawn do
+      start = Time.local
+      Library.default.scan
+      ms = (Time.local - start).total_milliseconds
+      Logger.info "Re-scanned #{Library.default.title_ids.size} titles \
+        in #{ms}ms"
+    end
   end
 
   def initialize

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -18,7 +18,7 @@ class Library
   def self.load_instance
     dir = Config.current.library_path
     return unless Dir.exists? dir
-    instance_file_path = File.join path, "library.yml.zip"
+    instance_file_path = File.join dir, "library.yml.zip"
     return unless File.exists? instance_file_path
 
     zip_file = Compress::Zip::File.new instance_file_path
@@ -38,7 +38,7 @@ class Library
 
     zip_file.close
 
-    scan
+    Library.default.scan
   end
 
   def initialize

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -153,8 +153,9 @@ class Library
       title = @title_hash[title_id]
       existence = title.examine examine_context
       unless existence
+        examine_context["deleted_title_ids"].concat title.deep_titles.map &.id
+        examine_context["deleted_entry_ids"].concat title.deep_entries.map &.id
         @title_hash.delete title_id
-        examine_context["deleted_title_ids"] << title_id
       end
       existence
     end

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -153,7 +153,8 @@ class Library
       title = @title_hash[title_id]
       existence = title.examine examine_context
       unless existence
-        examine_context["deleted_title_ids"].concat [title_id] + title.deep_titles.map &.id
+        examine_context["deleted_title_ids"].concat [title_id] +
+                                                    title.deep_titles.map &.id
         examine_context["deleted_entry_ids"].concat title.deep_entries.map &.id
       end
       existence

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -183,7 +183,8 @@ class Library
     ms = (Time.local - start).total_milliseconds
     Logger.info "Scanned #{@title_ids.size} titles in #{ms}ms"
 
-    Storage.default.mark_unavailable
+    Storage.default.mark_unavailable examine_context["deleted_entry_ids"],
+      examine_context["deleted_title_ids"]
 
     spawn do
       save_instance

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -98,6 +98,7 @@ class Library
   end
 
   def scan
+    start = Time.local
     unless Dir.exists? @dir
       Logger.info "The library directory #{@dir} does not exist. " \
                   "Attempting to create it"
@@ -122,7 +123,8 @@ class Library
     storage.bulk_insert_ids
     storage.close
 
-    Logger.debug "Scan completed"
+    ms = (Time.local - start).total_milliseconds
+    Logger.debug "Scan completed. #{ms}ms"
     Storage.default.mark_unavailable
   end
 

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -29,22 +29,26 @@ class Library
       zip_file.close
       return
     end
+    is_loaded = false
     begin
       instance_file.open do |content|
         @@default = Library.from_yaml content
       end
+      is_loaded = true
     rescue e
       Logger.error e
     end
 
     zip_file.close
 
-    spawn do
-      start = Time.local
-      Library.default.scan
-      ms = (Time.local - start).total_milliseconds
-      Logger.info "Re-scanned #{Library.default.title_ids.size} titles \
-        in #{ms}ms"
+    if is_loaded
+      spawn do
+        start = Time.local
+        Library.default.scan
+        ms = (Time.local - start).total_milliseconds
+        Logger.info "Re-scanned #{Library.default.title_ids.size} titles \
+          in #{ms}ms"
+      end
     end
   end
 

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -144,14 +144,20 @@ class Library
 
     storage = Storage.new auto_close: false
 
+    @title_ids.select! do |title_id|
+      title = @title_hash[title_id]
+      title.examine
+    end
+    remained_title_dirs = @title_ids.map { |id| title_hash[id].dir }
+
     (Dir.entries @dir)
       .select { |fn| !fn.starts_with? "." }
       .map { |fn| File.join @dir, fn }
+      .select { |path| !(remained_title_dirs.includes? path) }
       .select { |path| File.directory? path }
       .map { |path| Title.new path, "" }
       .select { |title| !(title.entries.empty? && title.titles.empty?) }
       .sort! { |a, b| a.title <=> b.title }
-      .tap { |_| @title_ids.clear }
       .each do |title|
         @title_hash[title.id] = title
         @title_ids << title.id

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -133,8 +133,9 @@ class Library
 
     storage = Storage.new auto_close: false
 
+    count = Config.current.forcely_yield_count
     examine_context : ExamineContext = {
-      file_counter:              (YieldCounter.new 1000),
+      file_counter:              (YieldCounter.new count),
       cached_contents_signature: {} of String => String,
       deleted_title_ids:         [] of String,
       deleted_entry_ids:         [] of String,

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -101,7 +101,10 @@ class Title
     @title_ids.select! do |title_id|
       title = Library.default.get_title! title_id
       existence = title.examine context
-      Library.default.title_hash.delete title_id unless existence
+      unless existence
+        Library.default.title_hash.delete title_id
+        context["deleted_title_ids"] << title_id
+      end
       existence
     end
     remained_title_dirs = @title_ids.map do |title_id|
@@ -110,7 +113,11 @@ class Title
     end
 
     previous_entries_size = @entries.size
-    @entries.select! { |entry| File.exists? entry.zip_path }
+    @entries.select! do |entry|
+      existence = File.exists? entry.zip_path
+      context["deleted_entry_ids"] << entry.id unless existence
+      existence
+    end
     remained_entry_zip_paths = @entries.map &.zip_path
 
     is_titles_added = false

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -95,7 +95,9 @@ class Title
     previous_titles_size = @title_ids.size
     @title_ids.select! do |title_id|
       title = Library.default.get_title! title_id
-      title.examine cache
+      existence = title.examine cache
+      Library.default.title_hash.delete title_id unless existence
+      existence
     end
     remained_title_dirs = @title_ids.map do |title_id|
       title = Library.default.get_title! title_id

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -10,9 +10,13 @@ class Title
     entry_cover_url_cache : Hash(String, String)?
   setter entry_cover_url_cache : Hash(String, String)?
 
+  @[YAML::Field(ignore: true)]
   @entry_display_name_cache : Hash(String, String)?
+  @[YAML::Field(ignore: true)]
   @entry_cover_url_cache : Hash(String, String)?
+  @[YAML::Field(ignore: true)]
   @cached_display_name : String?
+  @[YAML::Field(ignore: true)]
   @cached_cover_url : String?
 
   def initialize(@dir : String, @parent_id)

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -115,7 +115,7 @@ class Title
     previous_entries_size = @entries.size
     @entries.select! do |entry|
       existence = File.exists? entry.zip_path
-      yield_process_file context
+      context["file_counter"].count_and_yield
       context["deleted_entry_ids"] << entry.id unless existence
       existence
     end

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -80,7 +80,7 @@ class Title
   # - When the title exists and its contents signature is still the same, we
   #     return true so it can be reused without rescanning
   def examine(context : ExamineContext) : Bool
-    return false unless Dir.exists? @dir # No title, Remove this
+    return false unless Dir.exists? @dir
     contents_signature = Dir.contents_signature @dir,
       context["cached_contents_signature"]
     return true if @contents_signature == contents_signature

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -115,6 +115,7 @@ class Title
     previous_entries_size = @entries.size
     @entries.select! do |entry|
       existence = File.exists? entry.zip_path
+      yield_process_file context
       context["deleted_entry_ids"] << entry.id unless existence
       existence
     end

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -70,14 +70,21 @@ class Title
     end
   end
 
+  # Utility method used in library rescanning.
+  # - When the title does not exist on the file system anymore, return false
+  #     and let it be deleted from the libaray instance
+  # - When the title exists, but its contents sigature is now different from
+  #     the cache, it means some of its content (nested titles or entries)
+  #     has been added, deleted, or renamed. In this case we update its
+  #     contents signature and instance variables
+  # - When the title exists and its contents sigature is still the same, we
+  #     return true so it can be reused without rescanning
   def examine(context : ExamineContext) : Bool
     return false unless Dir.exists? @dir # No title, Remove this
     contents_signature = Dir.contents_signature @dir,
       context["cached_contents_signature"], context["file_counter"]
-    # Not changed. Reuse this
     return true if @contents_signature == contents_signature
 
-    # Fix title
     @contents_signature = contents_signature
     @signature = Dir.signature @dir
     storage = Storage.default
@@ -160,7 +167,7 @@ class Title
       end
     end
 
-    true # Fixed, reuse this
+    true
   end
 
   alias SortContext = NamedTuple(username: String, opt: SortOptions)

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -72,12 +72,12 @@ class Title
 
   # Utility method used in library rescanning.
   # - When the title does not exist on the file system anymore, return false
-  #     and let it be deleted from the libaray instance
-  # - When the title exists, but its contents sigature is now different from
+  #     and let it be deleted from the library instance
+  # - When the title exists, but its contents signature is now different from
   #     the cache, it means some of its content (nested titles or entries)
   #     has been added, deleted, or renamed. In this case we update its
   #     contents signature and instance variables
-  # - When the title exists and its contents sigature is still the same, we
+  # - When the title exists and its contents signature is still the same, we
   #     return true so it can be reused without rescanning
   def examine(context : ExamineContext) : Bool
     return false unless Dir.exists? @dir # No title, Remove this

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -102,7 +102,8 @@ class Title
       title = Library.default.get_title! title_id
       existence = title.examine context
       unless existence
-        context["deleted_title_ids"].concat [title_id] + title.deep_titles.map &.id
+        context["deleted_title_ids"].concat [title_id] +
+                                            title.deep_titles.map &.id
         context["deleted_entry_ids"].concat title.deep_entries.map &.id
       end
       existence

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -19,7 +19,7 @@ class Title
   @[YAML::Field(ignore: true)]
   @cached_cover_url : String?
 
-  def initialize(@dir : String, @parent_id, cache : Hash(String, String)? = nil)
+  def initialize(@dir : String, @parent_id, cache = {} of String => String)
     storage = Storage.default
     @signature = Dir.signature dir
     id = storage.get_title_id dir, signature
@@ -43,7 +43,7 @@ class Title
       next if fn.starts_with? "."
       path = File.join dir, fn
       if File.directory? path
-        title = Title.new path, @id
+        title = Title.new path, @id, cache
         next if title.entries.size == 0 && title.titles.size == 0
         Library.default.title_hash[title.id] = title
         @title_ids << title.id
@@ -73,7 +73,7 @@ class Title
   def examine(context : ExamineContext) : Bool
     return false unless Dir.exists? @dir # No title, Remove this
     contents_signature = Dir.contents_signature @dir,
-      context["cached_contents_signature"]
+      context["cached_contents_signature"], context["file_counter"]
     # Not changed. Reuse this
     return true if @contents_signature == contents_signature
 

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -102,8 +102,9 @@ class Title
       title = Library.default.get_title! title_id
       existence = title.examine context
       unless existence
+        context["deleted_title_ids"].concat title.deep_titles.map &.id
+        context["deleted_entry_ids"].concat title.deep_entries.map &.id
         Library.default.title_hash.delete title_id
-        context["deleted_title_ids"] << title_id
       end
       existence
     end

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -70,11 +70,12 @@ class Title
     end
   end
 
-  def examine : Bool
+  def examine(cache = {} of String => String) : Bool
     return false unless Dir.exists? @dir # no title, should be removed
-    contents_signature = Dir.contents_signature @dir
+    contents_signature = Dir.contents_signature @dir, cache
     # not changed, preserve
     return true if @contents_signature == contents_signature
+    puts "Contents changed in #{@dir}"
 
     # fix title
     @contents_signature = contents_signature
@@ -95,7 +96,7 @@ class Title
     previous_titles_size = @title_ids.size
     @title_ids.select! do |title_id|
       title = Library.default.get_title! title_id
-      title.examine
+      title.examine cache
     end
     remained_title_dirs = @title_ids.map do |id|
       title = Library.default.get_title! id

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -2,6 +2,8 @@ require "digest"
 require "../archive"
 
 class Title
+  include YAML::Serializable
+
   getter dir : String, parent_id : String, title_ids : Array(String),
     entries : Array(Entry), title : String, id : String,
     encoded_title : String, mtime : Time, signature : UInt64,

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -102,9 +102,8 @@ class Title
       title = Library.default.get_title! title_id
       existence = title.examine context
       unless existence
-        context["deleted_title_ids"].concat title.deep_titles.map &.id
+        context["deleted_title_ids"].concat [title_id] + title.deep_titles.map &.id
         context["deleted_entry_ids"].concat title.deep_entries.map &.id
-        Library.default.title_hash.delete title_id
       end
       existence
     end

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -75,7 +75,6 @@ class Title
     contents_signature = Dir.contents_signature @dir, cache
     # not changed, preserve
     return true if @contents_signature == contents_signature
-    puts "Contents changed in #{@dir}"
 
     # fix title
     @contents_signature = contents_signature

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -32,6 +32,7 @@ class Title
       })
     end
     @id = id
+    @contents_signature = Dir.contents_signature dir
     @title = File.basename dir
     @encoded_title = URI.encode @title
     @title_ids = [] of String
@@ -71,12 +72,13 @@ class Title
 
   def examine : Bool
     return false unless Dir.exists? @dir # no title, should be removed
-    signature = Dir.signature @dir
-    # `signature` doesn't reflect movings, renames in nested titles
-    # return true if @signature == signature # not changed, preserve
+    contents_signature = Dir.contents_signature @dir
+    # not changed, preserve
+    return true if @contents_signature == contents_signature
 
     # fix title
-    @signature = signature
+    @contents_signature = contents_signature
+    @signature = Dir.signature @dir
     storage = Storage.default
     id = storage.get_title_id dir, signature
     if id.nil?

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -19,7 +19,7 @@ class Title
   @[YAML::Field(ignore: true)]
   @cached_cover_url : String?
 
-  def initialize(@dir : String, @parent_id, cache : Hash(String, String)?)
+  def initialize(@dir : String, @parent_id, cache : Hash(String, String)? = nil)
     storage = Storage.default
     @signature = Dir.signature dir
     id = storage.get_title_id dir, signature
@@ -68,10 +68,6 @@ class Title
     @entries.sort! do |a, b|
       sorter.compare a.title, b.title
     end
-  end
-
-  def self.new(dir : String, parent_id)
-    new dir, parent_id, nil
   end
 
   def examine(context : ExamineContext) : Bool

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -69,6 +69,12 @@ class Title
     end
   end
 
+  def examine : Bool
+    return false unless Dir.exists? @dir
+    signature = Dir.signature @dir
+    return @signature == signature
+  end
+
   def to_slim_json : String
     JSON.build do |json|
       json.object do

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -71,12 +71,12 @@ class Title
   end
 
   def examine(cache = {} of String => String) : Bool
-    return false unless Dir.exists? @dir # no title, should be removed
+    return false unless Dir.exists? @dir # No title, Remove this
     contents_signature = Dir.contents_signature @dir, cache
-    # not changed, preserve
+    # Not changed. Reuse this
     return true if @contents_signature == contents_signature
 
-    # fix title
+    # Fix title
     @contents_signature = contents_signature
     @signature = Dir.signature @dir
     storage = Storage.default
@@ -97,8 +97,8 @@ class Title
       title = Library.default.get_title! title_id
       title.examine cache
     end
-    remained_title_dirs = @title_ids.map do |id|
-      title = Library.default.get_title! id
+    remained_title_dirs = @title_ids.map do |title_id|
+      title = Library.default.get_title! title_id
       title.dir
     end
 
@@ -148,7 +148,7 @@ class Title
       end
     end
 
-    return true # this could be recycled
+    true # Fixed, reuse this
   end
 
   def to_slim_json : String

--- a/src/library/types.cr
+++ b/src/library/types.cr
@@ -140,3 +140,8 @@ alias ExamineContext = NamedTuple(
   deleted_title_ids: Array(String),
   deleted_entry_ids: Array(String)
 )
+
+def yield_process_file(context : ExamineContext)
+  context["file_count"] += 1
+  Fiber.yield if context["file_count"] % 1000 == 0
+end

--- a/src/library/types.cr
+++ b/src/library/types.cr
@@ -135,7 +135,7 @@ class TitleInfo
 end
 
 class YieldCounter
-  setter threshold : Int32
+  @file_count : UInt32
 
   def initialize(@threshold : Int32)
     @file_count = 0
@@ -143,7 +143,7 @@ class YieldCounter
 
   def count_and_yield
     @file_count += 1
-    Fiber.yield if @file_count % @threshold == 0
+    Fiber.yield if @threshold > 0 && @file_count % @threshold == 0
   end
 end
 

--- a/src/library/types.cr
+++ b/src/library/types.cr
@@ -133,3 +133,10 @@ class TitleInfo
     LRUCache.set generate_cache_entry key, self.to_json
   end
 end
+
+alias ExamineContext = NamedTuple(
+  file_count: Int32,
+  cached_contents_signature: Hash(String, String),
+  deleted_title_ids: Array(String),
+  deleted_entry_ids: Array(String)
+)

--- a/src/library/types.cr
+++ b/src/library/types.cr
@@ -134,14 +134,21 @@ class TitleInfo
   end
 end
 
+class YieldCounter
+  setter threshold : Int32
+
+  def initialize(@threshold : Int32)
+    @file_count = 0
+  end
+
+  def count_and_yield
+    @file_count += 1
+    Fiber.yield if @file_count % @threshold == 0
+  end
+end
+
 alias ExamineContext = NamedTuple(
-  file_count: Int32,
+  file_counter: YieldCounter,
   cached_contents_signature: Hash(String, String),
   deleted_title_ids: Array(String),
-  deleted_entry_ids: Array(String)
-)
-
-def yield_process_file(context : ExamineContext)
-  context["file_count"] += 1
-  Fiber.yield if context["file_count"] % 1000 == 0
-end
+  deleted_entry_ids: Array(String))

--- a/src/mango.cr
+++ b/src/mango.cr
@@ -58,6 +58,7 @@ class CLI < Clim
       LRUCache.init
       Storage.default
       Queue.default
+      Library.load_instance
       Library.default
       Plugin::Downloader.default
 

--- a/src/storage.cr
+++ b/src/storage.cr
@@ -428,9 +428,10 @@ class Storage
     end
   end
 
-  # Limit mark targets with given arguments
-  # They should be checked again if they are really gone,
-  #   since they would be available which are renamed or moved
+  # Mark titles and entries that no longer exist on the file system as
+  #   unavailable. By supplying `id_candidates` and `titles_candidates`, it
+  #   only checks the existence of the candidate titles/entries to speed up
+  #   the process.
   def mark_unavailable(ids_candidates : Array(String)?,
                        titles_candidates : Array(String)?)
     MainFiber.run do

--- a/src/storage.cr
+++ b/src/storage.cr
@@ -467,6 +467,8 @@ class Storage
   end
 
   # Limit mark targets with given arguments
+  # They should be checked again if they are really gone,
+  #   since they would be available which are renamed or moved
   def mark_unavailable(ids_candidates : Array(String),
                        titles_candidates : Array(String))
     MainFiber.run do

--- a/src/storage.cr
+++ b/src/storage.cr
@@ -428,15 +428,11 @@ class Storage
     end
   end
 
-  def mark_unavailable
-    mark_unavailable nil, nil
-  end
-
   # Limit mark targets with given arguments
   # They should be checked again if they are really gone,
   #   since they would be available which are renamed or moved
-  def mark_unavailable(ids_candidates : Array(String) | Nil,
-                       titles_candidates : Array(String) | Nil)
+  def mark_unavailable(ids_candidates : Array(String)?,
+                       titles_candidates : Array(String)?)
     MainFiber.run do
       get_db do |db|
         # Detect dangling entry IDs

--- a/src/storage.cr
+++ b/src/storage.cr
@@ -438,7 +438,6 @@ class Storage
       get_db do |db|
         # Detect dangling entry IDs
         trash_ids = [] of String
-        # Use query builder instead?
         query = "select path, id from ids where unavailable = 0"
         unless ids_candidates.nil?
           query += " and id in (#{ids_candidates.join "," { |i| "'#{i}'" }})"

--- a/src/storage.cr
+++ b/src/storage.cr
@@ -467,13 +467,14 @@ class Storage
   end
 
   # Limit mark targets with given arguments
-  def mark_unavailable(trash_ids_candidates : Array(String), trash_titles_candidates : Array(String))
+  def mark_unavailable(ids_candidates : Array(String),
+                       titles_candidates : Array(String))
     MainFiber.run do
       get_db do |db|
         # Detect dangling entry IDs
         trash_ids = [] of String
         db.query "select path, id from ids where id in " \
-                 "(#{trash_ids_candidates.join "," { |i| "'#{i}'" }})" do |rs|
+                 "(#{ids_candidates.join "," { |i| "'#{i}'" }})" do |rs|
           rs.each do
             path = rs.read String
             fullpath = Path.new(path).expand(Config.current.library_path).to_s
@@ -490,7 +491,7 @@ class Storage
         # Detect dangling title IDs
         trash_titles = [] of String
         db.query "select path, id from titles where id in " \
-                 "(#{trash_titles_candidates.join "," { |i| "'#{i}'" }})" do |rs|
+                 "(#{titles_candidates.join "," { |i| "'#{i}'" }})" do |rs|
           rs.each do
             path = rs.read String
             fullpath = Path.new(path).expand(Config.current.library_path).to_s

--- a/src/util/signature.cr
+++ b/src/util/signature.cr
@@ -65,7 +65,7 @@ class Dir
         next if fn.starts_with? "."
         path = File.join dirname, fn
         if File.directory? path
-          signatures << Dir.contents_signature path, cache
+          signatures << Dir.contents_signature path, cache, counter
         else
           # Only add its signature value to `signatures` when it is a
           #   supported file

--- a/src/util/signature.cr
+++ b/src/util/signature.cr
@@ -55,7 +55,7 @@ class Dir
   #   - When a file added, moved, removed, renamed (including which in nested
   #       directories)
   def self.contents_signature(dirname, cache = {} of String => String) : String
-    return cache[dirname] if cache[dirname]?
+    return cache[dirname] if !cache.nil? && cache[dirname]?
     signatures = [] of String
     self.open dirname do |dir|
       dir.entries.sort.each do |fn|
@@ -71,7 +71,7 @@ class Dir
       end
     end
     hash = Digest::SHA1.hexdigest(signatures.join)
-    cache[dirname] = hash
+    cache[dirname] = hash unless cache.nil?
     hash
   end
 end

--- a/src/util/signature.cr
+++ b/src/util/signature.cr
@@ -70,7 +70,7 @@ class Dir
         end
       end
     end
-    hash = Digest::SHA1.hexdigest(signatures.sort.join)
+    hash = Digest::SHA1.hexdigest(signatures.join)
     cache[dirname] = hash
     hash
   end

--- a/src/util/signature.cr
+++ b/src/util/signature.cr
@@ -54,7 +54,8 @@ class Dir
   # Rescan conditions:
   #   - When a file added, moved, removed, renamed (including which in nested
   #       directories)
-  def self.contents_signature(dirname) : String
+  def self.contents_signature(dirname, cache = {} of String => String) : String
+    return cache[dirname] if cache[dirname]?
     signatures = [] of String
     self.open dirname do |dir|
       dir.entries.sort.each do |fn|
@@ -69,6 +70,8 @@ class Dir
         end
       end
     end
-    Digest::SHA1.hexdigest(signatures.sort.join)
+    hash = Digest::SHA1.hexdigest(signatures.sort.join)
+    cache[dirname] = hash
+    hash
   end
 end

--- a/src/util/signature.cr
+++ b/src/util/signature.cr
@@ -62,7 +62,7 @@ class Dir
         next if fn.starts_with? "."
         path = File.join dirname, fn
         if File.directory? path
-          signatures << Dir.contents_signature path
+          signatures << Dir.contents_signature path, cache
         else
           # Only add its signature value to `signatures` when it is a
           #   supported file

--- a/src/util/signature.cr
+++ b/src/util/signature.cr
@@ -56,6 +56,7 @@ class Dir
   #       directories)
   def self.contents_signature(dirname, cache = {} of String => String) : String
     return cache[dirname] if !cache.nil? && cache[dirname]?
+    Fiber.yield # Yield first
     signatures = [] of String
     self.open dirname do |dir|
       dir.entries.sort.each do |fn|


### PR DESCRIPTION
## Implementation

### 1. Make library instance serializable, implement `Library#save_instance` and `Library.load_instance`

I just added `YAML::Serializable` to `Entry`, `Title` and `Library`. I ignored some cache field. A filename of saved instance is `library.yml.zip`. In there, `instance.yml` is. My library (12,000 entries, about 500GB) makes 1.5MB zip file for this (8MB unzipped). It saves an instance file after every scanning. It loads instance file on boot and examine loaded titles via scanning.

### 2. Skip / Reuse titles when scanning.

After loading library instance, there are scanned titles. We should remove removed, renamed file, reuse remains and scan new.

* check existence at titles, remove removed ones
* make content-changed titles stable
* skip making a new instance of a title that already exists

See `Library#scan` and `Title#examine`.

#### `contents_signature`

The `signature` is good for identifying files even renamed, moved but finding re-scan targets does need to detect them. So I added `Dir.contents_signature` that returns a hash with filenames in a directory instead of their inode.

## Test / Efficiency

![image](https://user-images.githubusercontent.com/6760150/132969335-15f3846d-234c-45f7-a30a-5864a1c60a27.png)

It took 5 seconds to scan for a same library (not changed) about 90GB, 1,250 entries on a HDD via WSL2. I remember It took 3 minutes to full scan before.

![image](https://user-images.githubusercontent.com/6760150/132969443-f00452c1-50bf-4f4c-80f6-6560e8ff124b.png)

I added 11,000 entries and clicked a scan button. Since they're totally new, goes same as full scan. It took about 40 minutes to scan files, and took 3 minutes more to save an instance and mark unavailable items.

![image](https://user-images.githubusercontent.com/6760150/132969569-9951e0f5-02dd-4e3b-8338-ee5d1b647571.png)

I moved some files and clicked a scan button again. It took 3 minutes to scan files, also took 3 minutes to extra jobs. The log 'Contents changed in ~' is only printed when contents of directory is changed.

![image](https://user-images.githubusercontent.com/6760150/132969785-ccdd4903-b822-4cc7-bea6-d451c51a9fb7.png)

I clicked a scan file again. Since there is the same library, Mango just reuses them all. it took 45 seconds to scan files, which shows that the scanning is O(N). 10 more items (1,250 -> 12,050) took 10 more times (5 seconds -> 47 seconds).
By the way, I think it took too much time to just reuse 3 titles. Maybe `Dir.contents_signature` is really slow with a big title. I'll investigate on this.

Resolve #186 or other issues about slow scan. I didn't test it with rclone.

---

* the Mango server wouldn't answer quickly when scanning. I don't remember it was same before. I think I did something wrong with `spawn` in `load_instance`.
* I think my codes are not clean though :)