### PR TITLE
API Improvements

### DIFF
--- a/src/library/entry.cr
+++ b/src/library/entry.cr
@@ -46,28 +46,18 @@ class Entry
     file.close
   end
 
-  def to_slim_json : String
-    JSON.build do |json|
-      json.object do
-        {% for str in ["zip_path", "title", "size", "id"] %}
-        json.field {{str}}, @{{str.id}}
-      {% end %}
-        json.field "title_id", @book.id
-        json.field "pages" { json.number @pages }
-      end
-    end
-  end
-
-  def to_json(json : JSON::Builder)
+  def build_json(json : JSON::Builder, *, slim = false)
     json.object do
       {% for str in ["zip_path", "title", "size", "id"] %}
         json.field {{str}}, @{{str.id}}
       {% end %}
       json.field "title_id", @book.id
-      json.field "display_name", @book.display_name @title
-      json.field "cover_url", cover_url
       json.field "pages" { json.number @pages }
-      json.field "mtime" { json.number @mtime.to_unix }
+      unless slim
+        json.field "display_name", @book.display_name @title
+        json.field "cover_url", cover_url
+        json.field "mtime" { json.number @mtime.to_unix }
+      end
     end
   end
 

--- a/src/library/entry.cr
+++ b/src/library/entry.cr
@@ -46,17 +46,19 @@ class Entry
     file.close
   end
 
-  def build_json(json : JSON::Builder, *, slim = false)
-    json.object do
-      {% for str in ["zip_path", "title", "size", "id"] %}
+  def build_json(*, slim = false)
+    JSON.build do |json|
+      json.object do
+        {% for str in ["zip_path", "title", "size", "id"] %}
         json.field {{str}}, @{{str.id}}
       {% end %}
-      json.field "title_id", @book.id
-      json.field "pages" { json.number @pages }
-      unless slim
-        json.field "display_name", @book.display_name @title
-        json.field "cover_url", cover_url
-        json.field "mtime" { json.number @mtime.to_unix }
+        json.field "title_id", @book.id
+        json.field "pages" { json.number @pages }
+        unless slim
+          json.field "display_name", @book.display_name @title
+          json.field "cover_url", cover_url
+          json.field "mtime" { json.number @mtime.to_unix }
+        end
       end
     end
   end

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -65,26 +65,18 @@ class Library
     titles.flat_map &.deep_entries
   end
 
-  def to_slim_json : String
-    JSON.build do |json|
-      json.object do
-        json.field "dir", @dir
-        json.field "titles" do
-          json.array do
-            self.titles.each do |title|
-              json.raw title.to_slim_json
-            end
-          end
-        end
-      end
-    end
-  end
-
-  def to_json(json : JSON::Builder)
+  def build_json(json : JSON::Builder, *, slim = false, shallow = false)
     json.object do
       json.field "dir", @dir
       json.field "titles" do
-        json.raw self.titles.to_json
+        json.array do
+          self.titles.each do |title|
+            raw = JSON.build do |j|
+              title.build_json j, slim: slim, shallow: shallow
+            end
+            json.raw raw
+          end
+        end
       end
     end
   end

--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -65,16 +65,15 @@ class Library
     titles.flat_map &.deep_entries
   end
 
-  def build_json(json : JSON::Builder, *, slim = false, shallow = false)
-    json.object do
-      json.field "dir", @dir
-      json.field "titles" do
-        json.array do
-          self.titles.each do |title|
-            raw = JSON.build do |j|
-              title.build_json j, slim: slim, shallow: shallow
+  def build_json(*, slim = false, shallow = false)
+    JSON.build do |json|
+      json.object do
+        json.field "dir", @dir
+        json.field "titles" do
+          json.array do
+            self.titles.each do |title|
+              json.raw title.build_json(slim: slim, shallow: shallow)
             end
-            json.raw raw
           end
         end
       end

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -63,7 +63,10 @@ class Title
     end
   end
 
-  def build_json(json : JSON::Builder, *, slim = false, shallow = false)
+  alias SortContext = NamedTuple(username: String, opt: SortOptions)
+
+  def build_json(json : JSON::Builder, *, slim = false, shallow = false,
+                 sort_context : SortContext? = nil)
     json.object do
       {% for str in ["dir", "title", "id"] %}
         json.field {{str}}, @{{str.id}}
@@ -87,7 +90,13 @@ class Title
         end
         json.field "entries" do
           json.array do
-            @entries.each do |entry|
+            _entries = if sort_context
+                         sorted_entries sort_context[:username],
+                           sort_context[:opt]
+                       else
+                         @entries
+                       end
+            _entries.each do |entry|
               raw = JSON.build do |j|
                 entry.build_json j, slim: slim
               end

--- a/src/routes/api.cr
+++ b/src/routes/api.cr
@@ -158,10 +158,9 @@ struct APIRouter
         slim = !env.params.query["slim"]?.nil?
         shallow = !env.params.query["shallow"]?.nil?
 
-        json = JSON.build do |j|
-          title.build_json j, slim: slim, shallow: shallow,
-            sort_context: {username: username, opt: sort_opt}
-        end
+        send_json env, title.build_json(slim: slim, shallow: shallow,
+          sort_context: {username: username,
+                         opt:      sort_opt})
       rescue e
         Logger.error e
         env.response.status_code = 404
@@ -184,10 +183,7 @@ struct APIRouter
       slim = !env.params.query["slim"]?.nil?
       shallow = !env.params.query["shallow"]?.nil?
 
-      json = JSON.build do |j|
-        Library.default.build_json j, slim: slim, shallow: shallow
-      end
-      send_json env, json
+      send_json env, Library.default.build_json(slim: slim, shallow: shallow)
     end
 
     Koa.describe "Triggers a library scan"


### PR DESCRIPTION
This PR updates the following API endpoints:

- `/api/library`:
  - adds the `shallow` parameter to return only the top-level titles, without their nested titles and entries

- `/api/book/:title_id`
  - adds the `shallow` parameter to return only the title information, without its entries and nested titles
  - adds the `sort` and `ascend` parameters to control the sorting method and direction of entries