### PR TITLE
Avoid a unnecessary sorting

### DIFF
--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -380,7 +380,7 @@ class Title
     cached_sum = LRUCache.get key
     return cached_sum[1] if cached_sum.is_a? Tuple(String, Int32) &&
                             cached_sum[0] == sig
-    sum = load_progress_for_all_entries(username).sum +
+    sum = load_progress_for_all_entries(username, nil, true).sum +
           titles.flat_map(&.deep_read_page_count username).sum
     LRUCache.set generate_cache_entry key, {sig, sum}
     sum


### PR DESCRIPTION
It's unnecessary to call `sorted_entries` in `load_progress_for_all_entries` at `deep_read_page_count`, because we use its aggregated sum. It would make an initial page loading fast.

I didn't test yet in a large library, but it will be builded soon

---

I tested it. it seems ok!