### PR TITLE
auto download mango-arm64v8.o and use base ubuntu docker image 

### DIFF
--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:18.04
+FROM arm64v8/ubuntu:18.04 as builder
 
 RUN apt-get update && apt-get install -y wget git make llvm-8 llvm-8-dev g++ libsqlite3-dev libyaml-dev libgc-dev libssl-dev libcrypto++-dev libevent-dev libgmp-dev zlib1g-dev libpcre++-dev pkg-config libarchive-dev libxml2-dev libacl1-dev nettle-dev liblzo2-dev liblzma-dev libbz2-dev libjpeg-turbo8-dev libpng-dev libtiff-dev
 
@@ -7,8 +7,24 @@ RUN git clone https://github.com/kostya/myhtml && cd myhtml/src/ext && git check
 RUN git clone https://github.com/jessedoyle/duktape.cr && cd duktape.cr/ext && git checkout v1.0.0 && make && cd ..
 RUN git clone https://github.com/hkalexling/image_size.cr && cd image_size.cr && git checkout v0.5.0 && make && cd ..
 
-COPY mango-arm64v8.o .
+RUN wget -O - https://api.github.com/repos/hkalexling/Mango/releases/latest \
+ | grep mango-arm64v8.o \
+ | cut -d : -f 2,3 \
+ | tail -1 \
+ | tr -d \" \
+ | wget -qi -
 
 RUN cc 'mango-arm64v8.o' -o '/usr/local/bin/mango' -rdynamic -lxml2 -L/image_size.cr/ext/libwebp -lwebp -L/image_size.cr/ext/stbi -lstbi /myhtml/src/ext/modest-c/lib/libmodest_static.a -L/duktape.cr/src/.build/lib -L/duktape.cr/src/.build/include -lduktape -lm `pkg-config libarchive --libs` -lz `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'` `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libcrypto || printf %s '-lcrypto'` -lgmp -lsqlite3 -lyaml -lpcre -lm /usr/lib/aarch64-linux-gnu/libgc.so -lpthread /crystal/src/ext/libcrystal.a -levent -lrt -ldl -L/usr/bin/../lib/crystal/lib -L/usr/bin/../lib/crystal/lib
+
+FROM  arm64v8/ubuntu:18.04
+WORKDIR /
+
+# Install runtime dependencies
+RUN apt update \
+    && apt install libxml2 libarchive13 libssl1.1 libsqlite3-0 libyaml-0-2 libgc1c2 libevent-2.1-6 -y \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/bin/mango /usr/local/bin/mango
 
 CMD ["/usr/local/bin/mango"]


### PR DESCRIPTION
Added auto download mango-arm64v8.o from release page.
Use base ubuntu image to run mango server.

Tested on RPI4.