### PR TITLE
Fix bug on scanning

### DIFF
--- a/src/library/library.cr
+++ b/src/library/library.cr
@@ -136,8 +136,12 @@ class Library
       deleted_entry_ids:         [] of String,
     }
 
+    library_paths = (Dir.entries @dir)
+      .select { |fn| !fn.starts_with? "." }
+      .map { |fn| File.join @dir, fn }
     @title_ids.select! do |title_id|
       title = @title_hash[title_id]
+      next false unless library_paths.includes? title.dir
       existence = title.examine examine_context
       unless existence
         examine_context["deleted_title_ids"].concat [title_id] +
@@ -152,9 +156,7 @@ class Library
     end
 
     cache = examine_context["cached_contents_signature"]
-    (Dir.entries @dir)
-      .select { |fn| !fn.starts_with? "." }
-      .map { |fn| File.join @dir, fn }
+    library_paths
       .select { |path| !(remained_title_dirs.includes? path) }
       .select { |path| File.directory? path }
       .map { |path| Title.new path, "", cache }

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -161,6 +161,7 @@ class Title
         if entry.pages > 0 || entry.err_msg
           @entries << entry
           is_entries_added = true
+          context["deleted_entry_ids"].select! { |id| entry.id != id }
         end
       end
     end

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -145,12 +145,12 @@ class Title
         # We think they are removed, but they are here!
         # Cancel reserved jobs
         revival_title_ids = [title.id] + title.deep_titles.map &.id
-        context["deleted_title_ids"].select! do |id|
-          !(revival_title_ids.includes? id)
+        context["deleted_title_ids"].select! do |deleted_title_id|
+          !(revival_title_ids.includes? deleted_title_id)
         end
         revival_entry_ids = title.deep_entries.map &.id
-        context["deleted_entry_ids"].select! do |id|
-          !(revival_entry_ids.includes? id)
+        context["deleted_entry_ids"].select! do |deleted_entry_id|
+          !(revival_entry_ids.includes? deleted_entry_id)
         end
 
         next
@@ -161,7 +161,9 @@ class Title
         if entry.pages > 0 || entry.err_msg
           @entries << entry
           is_entries_added = true
-          context["deleted_entry_ids"].select! { |id| entry.id != id }
+          context["deleted_entry_ids"].select! do |deleted_entry_id|
+            entry.id != deleted_entry_id
+          end
         end
       end
     end

--- a/src/library/title.cr
+++ b/src/library/title.cr
@@ -102,7 +102,11 @@ class Title
 
     previous_titles_size = @title_ids.size
     @title_ids.select! do |title_id|
-      title = Library.default.get_title! title_id
+      title = Library.default.get_title title_id
+      unless title # for if data consistency broken
+        context["deleted_title_ids"].concat [title_id]
+        next false
+      end
       existence = title.examine context
       unless existence
         context["deleted_title_ids"].concat [title_id] +
@@ -137,6 +141,18 @@ class Title
         Library.default.title_hash[title.id] = title
         @title_ids << title.id
         is_titles_added = true
+
+        # We think they are removed, but they are here!
+        # Cancel reserved jobs
+        revival_title_ids = [title.id] + title.deep_titles.map &.id
+        context["deleted_title_ids"].select! do |id|
+          !(revival_title_ids.includes? id)
+        end
+        revival_entry_ids = title.deep_entries.map &.id
+        context["deleted_entry_ids"].select! do |id|
+          !(revival_entry_ids.includes? id)
+        end
+
         next
       end
       if is_supported_file path
@@ -167,7 +183,12 @@ class Title
       end
     end
 
-    true
+    if @title_ids.size > 0 || @entries.size > 0
+      true
+    else
+      context["deleted_title_ids"].concat [@id]
+      false
+    end
   end
 
   alias SortContext = NamedTuple(username: String, opt: SortOptions)

--- a/src/routes/admin.cr
+++ b/src/routes/admin.cr
@@ -61,7 +61,7 @@ struct AdminRouter
       redirect_url = URI.new \
         path: "/admin/user/edit",
         query: hash_to_query({"username" => original_username, \
-           "admin" => admin, "error" => e.message})
+                                 "admin" => admin, "error" => e.message})
       redirect env, redirect_url.to_s
     end
 

--- a/src/routes/admin.cr
+++ b/src/routes/admin.cr
@@ -61,7 +61,7 @@ struct AdminRouter
       redirect_url = URI.new \
         path: "/admin/user/edit",
         query: hash_to_query({"username" => original_username, \
-                                 "admin" => admin, "error" => e.message})
+           "admin" => admin, "error" => e.message})
       redirect env, redirect_url.to_s
     end
 


### PR DESCRIPTION
Resolve #257

Mango think some titles removed but they are actually not. They are found in other directory.
Since they are checked as 'deleted', Mango removed them from `title_hash` after scan job over and mark them unavailable.

After make new titles or entries, cancel the reserved jobs for them if there are.