### PR TITLE
v0.26.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The official docker images are available on [Dockerhub](https://hub.docker.com/r
 ### CLI
 
 ```
-  Mango - Manga Server and Web Reader. Version 0.26.1
+  Mango - Manga Server and Web Reader. Version 0.26.2
 
   Usage:
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: mango
-version: 0.26.1
+version: 0.26.2
 
 authors:
   - Alex Ling <hkalexling@gmail.com>

--- a/src/mango.cr
+++ b/src/mango.cr
@@ -7,7 +7,7 @@ require "option_parser"
 require "clim"
 require "tallboy"
 
-MANGO_VERSION = "0.26.1"
+MANGO_VERSION = "0.26.2"
 
 # From http://www.network-science.de/ascii/
 BANNER = %{

--- a/src/server.cr
+++ b/src/server.cr
@@ -23,6 +23,7 @@ class Server
     AdminRouter.new
     ReaderRouter.new
     APIRouter.new
+    OPDSRouter.new
 
     {% for path in %w(/api/* /uploads/* /img/*) %}
       options {{path}} do |env|


### PR DESCRIPTION
### Bug-Fixes

- The OPDS related routes (`/opds/*`) were accidentally deleted in v0.26.0. It's fixed in this released. Resolves comment [#255 (comment)](https://github.com/hkalexling/Mango/issues/255#issuecomment-1097588181)