### PR TITLE
Hide subscribe btn

### DIFF
--- a/public/js/plugin-download.js
+++ b/public/js/plugin-download.js
@@ -72,6 +72,9 @@ const component = () => {
 				});
 		},
 		pluginChanged() {
+			this.manga = undefined;
+			this.chapters = undefined;
+			this.mid = undefined;
 			this.loadPlugin(this.pid);
 			localStorage.setItem("plugin", this.pid);
 		},

--- a/public/js/plugin-download.js
+++ b/public/js/plugin-download.js
@@ -1,6 +1,7 @@
 const component = () => {
 	return {
 		plugins: [],
+		subscribable: false,
 		info: undefined,
 		pid: undefined,
 		chapters: undefined, // undefined: not searched yet, []: empty
@@ -60,6 +61,7 @@ const component = () => {
 				.then((data) => {
 					if (!data.success) throw new Error(data.error);
 					this.info = data.info;
+					this.subscribable = data.subscribable;
 					this.pid = pid;
 				})
 				.catch((e) => {
@@ -140,6 +142,7 @@ const component = () => {
 			if (!query) return;
 
 			this.manga = undefined;
+			this.mid = undefined;
 			if (this.info.version === 1) {
 				this.searchChapters(query);
 			} else {

--- a/src/logger.cr
+++ b/src/logger.cr
@@ -38,6 +38,7 @@ class Logger
     Log.setup do |c|
       c.bind "*", @@severity, @backend
       c.bind "db.*", :error, @backend
+      c.bind "duktape", :none, @backend
     end
   end
 

--- a/src/plugin/plugin.cr
+++ b/src/plugin/plugin.cr
@@ -223,6 +223,10 @@ class Plugin
     raise Error.new "Missing required fields in the Page type"
   end
 
+  def can_subscribe? : Bool
+    info.version > 1 && eval_exists?("newChapters")
+  end
+
   def search_manga(query : String)
     if info.version == 1
       raise Error.new "Manga searching is only available for plugins " \
@@ -325,6 +329,15 @@ class Plugin
 
   private def eval_json(str)
     JSON.parse eval(str).as String
+  end
+
+  private def eval_exists?(str) : Bool
+    @rt.eval str
+    true
+  rescue e : Duktape::ReferenceError
+    false
+  rescue e : Duktape::Error
+    raise Error.new e.message
   end
 
   private def def_helper_functions(sbx)

--- a/src/routes/api.cr
+++ b/src/routes/api.cr
@@ -871,13 +871,15 @@ struct APIRouter
         "version"      => Int32,
         "settings"     => {} of String => String,
       },
+      "subscribable" => Bool,
     }
     get "/api/admin/plugin/info" do |env|
       begin
         plugin = Plugin.new env.params.query["plugin"].as String
         send_json env, {
-          "success" => true,
-          "info"    => plugin.info,
+          "success"      => true,
+          "info"         => plugin.info,
+          "subscribable" => plugin.can_subscribe?,
         }.to_json
       rescue e
         Logger.error e

--- a/src/views/plugin-download.html.ecr
+++ b/src/views/plugin-download.html.ecr
@@ -133,8 +133,10 @@
           </template>
           <button class="uk-button uk-button-primary" @click.prevent="applyFilters()">Apply</button>
           <button class="uk-button uk-button-default" @click.prevent="clearFilters()">Clear</button>
-          <span class="uk-divider-vertical uk-margin-left uk-margin-right"></span>
-          <button class="uk-button uk-button-default" @click.prevent="UIkit.modal($refs.modal).show()" :disable="subscribing">Subscribe</button>
+          <span x-show="subscribable">
+            <span class="uk-divider-vertical uk-margin-left uk-margin-right"></span>
+            <button class="uk-button uk-button-default" @click.prevent="UIkit.modal($refs.modal).show()" :disable="subscribing">Subscribe</button>
+          </span>
         </form>
 
         <p class="uk-text-meta" x-show="chapters && chapters.length > chaptersLimit" x-text="`The manga has ${chapters ? chapters.length : 0} chapters, but Mango can only list up to ${chaptersLimit}. Please use the filters to narrow down your search.`"></p>


### PR DESCRIPTION
1. Hide the "Subscribe" button if a plugin is not "subscribable". A plugin is only subscribable if it's targets at least API v2, and implements the `newChapters` function.
2. Clear the page when switching plugins.