### PR TITLE
Fix Dir.contents_signature to detect valid image files

### DIFF
--- a/src/util/signature.cr
+++ b/src/util/signature.cr
@@ -64,11 +64,10 @@ class Dir
         path = File.join dirname, fn
         if File.directory? path
           signatures << Dir.contents_signature path, cache
-          signatures << fn if DirEntry.is_valid? path
         else
           # Only add its signature value to `signatures` when it is a
           #   supported file
-          signatures << fn if ArchiveEntry.is_valid? fn
+          signatures << fn if ArchiveEntry.is_valid?(fn) || is_supported_image_file(fn)
         end
         Fiber.yield
       end

--- a/src/util/signature.cr
+++ b/src/util/signature.cr
@@ -67,7 +67,9 @@ class Dir
         else
           # Only add its signature value to `signatures` when it is a
           #   supported file
-          signatures << fn if ArchiveEntry.is_valid?(fn) || is_supported_image_file(fn)
+          if ArchiveEntry.is_valid?(fn) || is_supported_image_file(fn)
+            signatures << fn
+          end
         end
         Fiber.yield
       end


### PR DESCRIPTION
Fixed a reported issue at [here](https://github.com/hkalexling/Mango/issues/215#issuecomment-1157632921)