### PR TITLE
Removal of Malicious Domain: polyfill.io

### DIFF
--- a/src/views/components/head.html.ecr
+++ b/src/views/components/head.html.ecr
@@ -8,7 +8,6 @@
   <link rel="icon" href="<%= base_url %>favicon.ico">
   <link rel="manifest" href="<%= base_url %>manifest.json">
 
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=MutationObserver%2Cdefault%2CmatchMedia&flats=gated"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
   <script type="module" src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.8.0/dist/alpine.min.js"></script>
   <script nomodule src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.8.0/dist/alpine-ie11.min.js" defer></script>


### PR DESCRIPTION
Removed malicious domain polyfill.io Based on the findings reported here: https://github.com/getmango/Mango/issues/363